### PR TITLE
refactor: replace MediatR with direct DI

### DIFF
--- a/src/OStats.API/Apis/DatasetsApi.cs
+++ b/src/OStats.API/Apis/DatasetsApi.cs
@@ -1,10 +1,8 @@
 using System.Runtime.CompilerServices;
 using DataServiceGrpc;
 using Grpc.Core;
-using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using OStats.API.Commands;
 using OStats.API.Dtos;
 using OStats.API.Extensions;
@@ -35,12 +33,12 @@ public static class DatasetsApi
     private static async Task<Results<Ok<BaseDatasetDto>, BadRequest<string>>> CreateDatasetHandler(
         [FromBody] CreateDatasetDto createDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] CreateDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new CreateDatasetCommand(userAuthId, createDto.Title, createDto.Source, createDto.Description);
-        var (result, baseDatasetDto) = await mediator.Send(command, cancellationToken);
+        var (result, baseDatasetDto) = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok(baseDatasetDto) : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -64,12 +62,12 @@ public static class DatasetsApi
     private static async Task<Results<Ok, BadRequest<string>>> DeleteDatasetHandler(
         Guid datasetId,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] DeleteDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new DeleteDatasetCommand(userAuthId, datasetId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -77,12 +75,12 @@ public static class DatasetsApi
         Guid datasetId,
         [FromBody] UpdateDatasetDto updateDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] UpdateDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new UpdateDatasetCommand(datasetId, userAuthId, updateDto.Title, updateDto.Source, updateDto.LastUpdatedAt, updateDto.Description);
-        var (result, baseDatasetDto) = await mediator.Send(command, cancellationToken);
+        var (result, baseDatasetDto) = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok(baseDatasetDto) : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -90,12 +88,12 @@ public static class DatasetsApi
         Guid datasetId,
         [FromBody] IngestDataDto ingestDataDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] IngestDataCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new IngestDataCommand(userAuthId, datasetId, ingestDataDto.Bucket, ingestDataDto.FileName);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -153,12 +151,12 @@ public static class DatasetsApi
         Guid datasetId,
         [FromBody] AddUserToDatasetDto addUserToDatasetDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] AddUserToDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new AddUserToDatasetCommand(userAuthId, datasetId, addUserToDatasetDto.UserId, addUserToDatasetDto.AccessLevel);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -166,12 +164,12 @@ public static class DatasetsApi
         Guid datasetId,
         Guid userId,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] RemoveUserFromDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new RemoveUserFromDatasetCommand(userAuthId, datasetId, userId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 }

--- a/src/OStats.API/Apis/ProjectsApi.cs
+++ b/src/OStats.API/Apis/ProjectsApi.cs
@@ -1,4 +1,3 @@
-using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using OStats.API.Commands;
@@ -30,12 +29,12 @@ public static class ProjectsApi
     private static async Task<Results<Ok<BaseProjectDto>, BadRequest<string>>> CreateProjectAsync(
         [FromBody] CreateProjectDto createDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] CreateProjectCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new CreateProjectCommand(userAuthId, createDto.Title, createDto.Description);
-        var (result, baseProject) = await mediator.Send(command, cancellationToken);
+        var (result, baseProject) = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok(baseProject) : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -60,23 +59,24 @@ public static class ProjectsApi
         Guid projectId,
         [FromBody] UpdateProjectDto updateDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] UpdateProjectCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new UpdateProjectCommand(projectId, userAuthId, updateDto.Title, updateDto.LastUpdatedAt, updateDto.Description);
-        var (result, baseProjectDto) = await mediator.Send(command, cancellationToken);
+        var (result, baseProjectDto) = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok(baseProjectDto) : TypedResults.BadRequest(result.ErrorMessage);
     }
 
     private static async Task<Results<Ok, BadRequest<string>>> DeleteProjectAsync(
         Guid projectId,
         HttpContext context,
-        [FromServices] IMediator mediator)
+        [FromServices] DeleteProjectCommandHandler commandHandler,
+        CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new DeleteProjectCommand(userAuthId, projectId);
-        var result = await mediator.Send(command);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -101,23 +101,25 @@ public static class ProjectsApi
         Guid projectId,
         [FromBody] AddUserToProjectDto addUserToProjectDto,
         HttpContext context,
-        [FromServices] IMediator mediator)
+        [FromServices] AddUserToProjectCommandHandler commandHandler,
+        CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new AddUserToProjectCommand(userAuthId, projectId, addUserToProjectDto.UserId, addUserToProjectDto.AccessLevel);
-        var result = await mediator.Send(command);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
+
     private static async Task<Results<Ok, BadRequest<string>>> RemoveUserFromProjectHandler(
         Guid projectId,
         Guid userId,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] RemoveUserFromProjectCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new RemoveUserFromProjectCommand(userAuthId, projectId, userId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -125,12 +127,12 @@ public static class ProjectsApi
         Guid projectId,
         Guid datasetId,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] LinkProjectToDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new LinkProjectToDatasetCommand(userAuthId, datasetId, projectId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
@@ -138,12 +140,12 @@ public static class ProjectsApi
         Guid projectId,
         Guid datasetId,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] UnlinkProjectToDatasetCommandHandler commandHandler,
         CancellationToken cancellationToken)
     {
         var userAuthId = context.GetUserAuthId();
         var command = new UnlinkProjectToDatasetCommand(userAuthId, datasetId, projectId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 }

--- a/src/OStats.API/Apis/UsersApi.cs
+++ b/src/OStats.API/Apis/UsersApi.cs
@@ -1,4 +1,3 @@
-using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using OStats.API.Commands;
@@ -35,7 +34,7 @@ public static class UsersApi
     private static async Task<Results<Ok<BaseUserDto>, BadRequest<string>>> CreateUserAsync(
         [FromBody] CreateUserDto createDto,
         HttpContext context,
-        [FromServices] IMediator mediator,
+        [FromServices] CreateUserCommandHandler commandHandler,
         Context dbContext,
         CancellationToken cancellationToken)
     {
@@ -47,7 +46,7 @@ public static class UsersApi
         }
 
         var command = new CreateUserCommand(createDto.Name, createDto.Email, userAuthId);
-        var (result, baseUserDto) = await mediator.Send(command, cancellationToken);
+        var (result, baseUserDto) = await commandHandler.Handle(command, cancellationToken);
         return result.Succeeded ? TypedResults.Ok(baseUserDto) : TypedResults.BadRequest(result.ErrorMessage);
     }
 

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
@@ -1,8 +1,6 @@
-using MediatR;
-
 namespace OStats.API.Commands;
 
-public sealed record AddAggregateHistoryEntryCommand : IRequest<bool>
+public sealed record AddAggregateHistoryEntryCommand
 {
     public required Guid AggregateId { get; init; }
     public required string AggregateType { get; init; }

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
@@ -1,6 +1,8 @@
+using MediatR;
+
 namespace OStats.API.Commands;
 
-public sealed record AddAggregateHistoryEntryCommand
+public sealed record AddAggregateHistoryEntryCommand : IRequest<bool>
 {
     public required Guid AggregateId { get; init; }
     public required string AggregateType { get; init; }

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommand.cs
@@ -1,6 +1,6 @@
 namespace OStats.API.Commands;
 
-public record AddAggregateHistoryEntryCommand
+public sealed record AddAggregateHistoryEntryCommand
 {
     public required Guid AggregateId { get; init; }
     public required string AggregateType { get; init; }

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class AddAggregateHistoryEntryCommandHandler : IConsumer<AddAggregateHistoryEntryCommand>
+public sealed class AddAggregateHistoryEntryCommandHandler : IConsumer<AddAggregateHistoryEntryCommand>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
@@ -1,10 +1,10 @@
-using MassTransit;
+using MediatR;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class AddAggregateHistoryEntryCommandHandler : IConsumer<AddAggregateHistoryEntryCommand>
+public sealed class AddAggregateHistoryEntryCommandHandler : IRequestHandler<AddAggregateHistoryEntryCommand, bool>
 {
     private readonly Context _context;
 
@@ -13,9 +13,8 @@ public sealed class AddAggregateHistoryEntryCommandHandler : IConsumer<AddAggreg
         _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task Consume(ConsumeContext<AddAggregateHistoryEntryCommand> context)
+    public async Task<bool> Handle(AddAggregateHistoryEntryCommand request, CancellationToken cancellationToken)
     {
-        var request = context.Message;
         _context.AggregatesHistoryEntries.Add(new AggregateHistoryEntry(
             request.AggregateId,
             request.AggregateType,
@@ -25,7 +24,9 @@ public sealed class AddAggregateHistoryEntryCommandHandler : IConsumer<AddAggreg
             request.EventDescription,
             request.TimeStamp
         ));
-        await _context.SaveChangesAsync();
-    }
 
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
 }

--- a/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
+++ b/src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class AddAggregateHistoryEntryCommandHandler : IRequestHandler<AddAggregateHistoryEntryCommand, bool>
+public sealed class AddAggregateHistoryEntryCommandHandler : CommandHandler<AddAggregateHistoryEntryCommand, bool>
 {
-    private readonly Context _context;
-
-    public AddAggregateHistoryEntryCommandHandler(Context context)
+    public AddAggregateHistoryEntryCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<bool> Handle(AddAggregateHistoryEntryCommand request, CancellationToken cancellationToken)
+    public override async Task<bool> Handle(AddAggregateHistoryEntryCommand request, CancellationToken cancellationToken)
     {
         _context.AggregatesHistoryEntries.Add(new AggregateHistoryEntry(
             request.AggregateId,
@@ -25,8 +23,7 @@ public sealed class AddAggregateHistoryEntryCommandHandler : IRequestHandler<Add
             request.TimeStamp
         ));
 
-        await _context.SaveChangesAsync(cancellationToken);
-
+        await SaveCommandHandlerChangesAsync(cancellationToken);
         return true;
     }
 }

--- a/src/OStats.API/Commands/AddUserToDatasetCommand.cs
+++ b/src/OStats.API/Commands/AddUserToDatasetCommand.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class AddUserToDatasetCommand : IRequest<DomainOperationResult>
+public sealed class AddUserToDatasetCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; set; }
     public Guid DatasetId { get; set; }

--- a/src/OStats.API/Commands/AddUserToDatasetCommand.cs
+++ b/src/OStats.API/Commands/AddUserToDatasetCommand.cs
@@ -1,10 +1,8 @@
-using MediatR;
 using OStats.Domain.Aggregates.DatasetAggregate;
-using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public sealed class AddUserToDatasetCommand : IRequest<DomainOperationResult>
+public sealed record AddUserToDatasetCommand
 {
     public string UserAuthId { get; set; }
     public Guid DatasetId { get; set; }

--- a/src/OStats.API/Commands/AddUserToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/AddUserToDatasetCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class AddUserToDatasetCommandHandler : IRequestHandler<AddUserToDatasetCommand, DomainOperationResult>
+public sealed class AddUserToDatasetCommandHandler : IRequestHandler<AddUserToDatasetCommand, DomainOperationResult>
 {
     private readonly Context _context;
     private readonly IPublishEndpoint _publishEndpoint;

--- a/src/OStats.API/Commands/AddUserToProjectCommand.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommand.cs
@@ -1,10 +1,8 @@
-using MediatR;
 using OStats.Domain.Aggregates.ProjectAggregate;
-using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public sealed class AddUserToProjectCommand : IRequest<DomainOperationResult>
+public sealed record AddUserToProjectCommand
 {
     public string UserAuthId { get; set; }
     public Guid ProjectId { get; set; }

--- a/src/OStats.API/Commands/AddUserToProjectCommand.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommand.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class AddUserToProjectCommand : IRequest<DomainOperationResult>
+public sealed class AddUserToProjectCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; set; }
     public Guid ProjectId { get; set; }

--- a/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class AddUserToProjectCommandHandler : IRequestHandler<AddUserToProjectCommand, DomainOperationResult>
+public sealed class AddUserToProjectCommandHandler : IRequestHandler<AddUserToProjectCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class AddUserToProjectCommandHandler : IRequestHandler<AddUserToProjectCommand, DomainOperationResult>
+public sealed class AddUserToProjectCommandHandler : CommandHandler<AddUserToProjectCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public AddUserToProjectCommandHandler(Context context)
+    public AddUserToProjectCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(AddUserToProjectCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(AddUserToProjectCommand request, CancellationToken cancellationToken)
     {
         var project = await _context.Projects.FindAsync(request.ProjectId, cancellationToken);
         if (project is null)
@@ -33,7 +31,7 @@ public sealed class AddUserToProjectCommandHandler : IRequestHandler<AddUserToPr
             return result;
         }
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
         return result;
     }
 }

--- a/src/OStats.API/Commands/Common/CommandHandler.cs
+++ b/src/OStats.API/Commands/Common/CommandHandler.cs
@@ -36,7 +36,7 @@ public abstract class CommandHandler<T, R>
     /// <param name="context">The database context.</param>
     /// <param name="publishEndpoint">The publish endpoint.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> or <paramref name="publishEndpoint"/> is null.</exception>
-    public CommandHandler(Context context, IPublishEndpoint publishEndpoint)
+    protected CommandHandler(Context context, IPublishEndpoint publishEndpoint)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _publishEndpoint = publishEndpoint ?? throw new ArgumentNullException(nameof(publishEndpoint));

--- a/src/OStats.API/Commands/Common/CommandHandler.cs
+++ b/src/OStats.API/Commands/Common/CommandHandler.cs
@@ -45,15 +45,14 @@ public abstract class CommandHandler<T, R> : IRequestHandler<T, R> where T : IRe
     }
 
     /// <summary>
-    /// Saves changes to the database context and publishes domain events.
+    /// Saves the changes made in the command handler asynchronously.
     /// </summary>
-    /// <param name="context">The database context.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains the number of state entries written to the database.</returns>
-    protected async Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected async Task SaveCommandHandlerChangesAsync(CancellationToken cancellationToken)
     {
         var domainEvents = _context.ChangeTracker.GetAggregateRootDomainEvents();
-        if (domainEvents is not null && domainEvents.Any())
+        if (domainEvents.Any())
         {
             foreach (var domainEvent in domainEvents)
             {
@@ -63,6 +62,6 @@ public abstract class CommandHandler<T, R> : IRequestHandler<T, R> where T : IRe
             }
         }
 
-        return await _context.SaveChangesAsync(cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/OStats.API/Commands/Common/CommandHandler.cs
+++ b/src/OStats.API/Commands/Common/CommandHandler.cs
@@ -1,5 +1,4 @@
 using MassTransit;
-using MediatR;
 using OStats.Infrastructure;
 using OStats.Infrastructure.Extensions;
 
@@ -7,11 +6,10 @@ namespace OStats.API.Commands.Common;
 
 /// <summary>
 /// Abstract base class for handling commands in the application.
-/// Implements the <see cref="IRequestHandler{T, R}"/> interface from MediatR.
 /// </summary>
 /// <typeparam name="T">The type of the command.</typeparam>
 /// <typeparam name="R">The type of the result.</typeparam>
-public abstract class CommandHandler<T, R> : IRequestHandler<T, R> where T : IRequest<R>
+public abstract class CommandHandler<T, R>
 {
     /// <summary>
     /// Handles the command.

--- a/src/OStats.API/Commands/Common/CommandHandler.cs
+++ b/src/OStats.API/Commands/Common/CommandHandler.cs
@@ -1,0 +1,68 @@
+using MassTransit;
+using MediatR;
+using OStats.Infrastructure;
+using OStats.Infrastructure.Extensions;
+
+namespace OStats.API.Commands.Common;
+
+/// <summary>
+/// Abstract base class for handling commands in the application.
+/// Implements the <see cref="IRequestHandler{T, R}"/> interface from MediatR.
+/// </summary>
+/// <typeparam name="T">The type of the command.</typeparam>
+/// <typeparam name="R">The type of the result.</typeparam>
+public abstract class CommandHandler<T, R> : IRequestHandler<T, R> where T : IRequest<R>
+{
+    /// <summary>
+    /// Handles the command.
+    /// Must be implemented by derived classes.
+    /// </summary>
+    /// <param name="command">The command to handle.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the result of the command.</returns>
+    public abstract Task<R> Handle(T command, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The database context.
+    /// </summary>
+    protected readonly Context _context;
+
+    /// <summary>
+    /// The publish endpoint for publishing domain events.
+    /// </summary>
+    protected readonly IPublishEndpoint _publishEndpoint;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandHandler{T, R}"/> class.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="publishEndpoint">The publish endpoint.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> or <paramref name="publishEndpoint"/> is null.</exception>
+    public CommandHandler(Context context, IPublishEndpoint publishEndpoint)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _publishEndpoint = publishEndpoint ?? throw new ArgumentNullException(nameof(publishEndpoint));
+    }
+
+    /// <summary>
+    /// Saves changes to the database context and publishes domain events.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the number of state entries written to the database.</returns>
+    protected async Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        var domainEvents = _context.ChangeTracker.GetAggregateRootDomainEvents();
+        if (domainEvents is not null && domainEvents.Any())
+        {
+            foreach (var domainEvent in domainEvents)
+            {
+                // Publish domain events to Outbox, which will get published to message broker after EF Core transaction is committed.
+                // ref: https://masstransit.io/documentation/configuration/middleware/outbox
+                await _publishEndpoint.Publish(domainEvent, domainEvent.GetType(), cancellationToken);
+            }
+        }
+
+        return await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/OStats.API/Commands/CreateDatasetCommand.cs
+++ b/src/OStats.API/Commands/CreateDatasetCommand.cs
@@ -1,10 +1,6 @@
-using MediatR;
-using OStats.API.Dtos;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public class CreateDatasetCommand : IRequest<ValueTuple<DomainOperationResult, BaseDatasetDto?>>
+public record CreateDatasetCommand
 {
     public string UserAuthId { get; set; }
     public string Title { get; set; }

--- a/src/OStats.API/Commands/CreateDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/CreateDatasetCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class CreateDatasetCommandHandler : IRequestHandler<CreateDatasetCommand, ValueTuple<DomainOperationResult, BaseDatasetDto?>>
+public sealed class CreateDatasetCommandHandler : IRequestHandler<CreateDatasetCommand, ValueTuple<DomainOperationResult, BaseDatasetDto?>>
 {
     private readonly Context _context;
     public CreateDatasetCommandHandler(Context context)

--- a/src/OStats.API/Commands/CreateProjectCommand.cs
+++ b/src/OStats.API/Commands/CreateProjectCommand.cs
@@ -1,10 +1,6 @@
-using MediatR;
-using OStats.API.Dtos;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public class CreateProjectCommand : IRequest<ValueTuple<DomainOperationResult, BaseProjectDto?>>
+public record CreateProjectCommand
 {
     public string UserAuthId { get; set; }
     public string Title { get; set; }

--- a/src/OStats.API/Commands/CreateProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/CreateProjectCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class CreateProjectCommandHandler : IRequestHandler<CreateProjectCommand, ValueTuple<DomainOperationResult, BaseProjectDto?>>
+public sealed class CreateProjectCommandHandler : IRequestHandler<CreateProjectCommand, ValueTuple<DomainOperationResult, BaseProjectDto?>>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/CreateUserCommand.cs
+++ b/src/OStats.API/Commands/CreateUserCommand.cs
@@ -1,10 +1,6 @@
-using MediatR;
-using OStats.API.Dtos;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class CreateUserCommand : IRequest<ValueTuple<DomainOperationResult, BaseUserDto?>>
+public sealed class CreateUserCommand
 {
     public string Name { get; }
     public string Email { get; }

--- a/src/OStats.API/Commands/CreateUserCommand.cs
+++ b/src/OStats.API/Commands/CreateUserCommand.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class CreateUserCommand : IRequest<ValueTuple<DomainOperationResult, BaseUserDto?>>
+public sealed class CreateUserCommand : IRequest<ValueTuple<DomainOperationResult, BaseUserDto?>>
 {
     public string Name { get; }
     public string Email { get; }

--- a/src/OStats.API/Commands/CreateUserCommandHandler.cs
+++ b/src/OStats.API/Commands/CreateUserCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, ValueTuple<DomainOperationResult, BaseUserDto?>>
+public sealed class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, ValueTuple<DomainOperationResult, BaseUserDto?>>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/DeleteDatasetCommand.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class DeleteDatasetCommand : IRequest<DomainOperationResult>
+public sealed record DeleteDatasetCommand
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/DeleteDatasetCommand.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class DeleteDatasetCommand : IRequest<DomainOperationResult>
+public sealed class DeleteDatasetCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
@@ -5,7 +5,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class DeleteDatasetCommandHandler : IRequestHandler<DeleteDatasetCommand, DomainOperationResult>
+public sealed class DeleteDatasetCommandHandler : IRequestHandler<DeleteDatasetCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
@@ -1,20 +1,18 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Aggregates.DatasetAggregate;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class DeleteDatasetCommandHandler : IRequestHandler<DeleteDatasetCommand, DomainOperationResult>
+public sealed class DeleteDatasetCommandHandler : CommandHandler<DeleteDatasetCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public DeleteDatasetCommandHandler(Context context)
+    public DeleteDatasetCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(DeleteDatasetCommand command, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(DeleteDatasetCommand command, CancellationToken cancellationToken)
     {
         var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
         if (user is null)
@@ -34,7 +32,7 @@ public sealed class DeleteDatasetCommandHandler : IRequestHandler<DeleteDatasetC
         }
 
         _context.Remove(dataset);
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return DomainOperationResult.Success;
     }

--- a/src/OStats.API/Commands/DeleteProjectCommand.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class DeleteProjectCommand : IRequest<DomainOperationResult>
+public sealed class DeleteProjectCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; }
     public Guid ProjectId { get; }

--- a/src/OStats.API/Commands/DeleteProjectCommand.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class DeleteProjectCommand : IRequest<DomainOperationResult>
+public sealed record DeleteProjectCommand
 {
     public string UserAuthId { get; }
     public Guid ProjectId { get; }

--- a/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class DeleteProjectCommandHandler : IRequestHandler<DeleteProjectCommand, DomainOperationResult>
+public sealed class DeleteProjectCommandHandler : IRequestHandler<DeleteProjectCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
@@ -1,4 +1,5 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Aggregates.ProjectAggregate;
 using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
 using OStats.Domain.Common;
@@ -6,16 +7,13 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class DeleteProjectCommandHandler : IRequestHandler<DeleteProjectCommand, DomainOperationResult>
+public sealed class DeleteProjectCommandHandler : CommandHandler<DeleteProjectCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public DeleteProjectCommandHandler(Context context)
+    public DeleteProjectCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(DeleteProjectCommand command, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(DeleteProjectCommand command, CancellationToken cancellationToken)
     {
         var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
         if (user is null)
@@ -36,7 +34,7 @@ public sealed class DeleteProjectCommandHandler : IRequestHandler<DeleteProjectC
         }
 
         _context.Remove(project);
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return DomainOperationResult.Success;
     }

--- a/src/OStats.API/Commands/IngestDataCommand.cs
+++ b/src/OStats.API/Commands/IngestDataCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class IngestDataCommand : IRequest<DomainOperationResult>
+public sealed class IngestDataCommand : IRequest<DomainOperationResult>
 {
     public Guid DatasetId { get; }
     public string UserAuthId { get; }

--- a/src/OStats.API/Commands/IngestDataCommand.cs
+++ b/src/OStats.API/Commands/IngestDataCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class IngestDataCommand : IRequest<DomainOperationResult>
+public sealed record IngestDataCommand
 {
     public Guid DatasetId { get; }
     public string UserAuthId { get; }

--- a/src/OStats.API/Commands/IngestDataCommandHandler.cs
+++ b/src/OStats.API/Commands/IngestDataCommandHandler.cs
@@ -1,23 +1,22 @@
 using DataServiceGrpc;
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Aggregates.DatasetAggregate;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class IngestDataCommandHandler : IRequestHandler<IngestDataCommand, DomainOperationResult>
+public sealed class IngestDataCommandHandler : CommandHandler<IngestDataCommand, DomainOperationResult>
 {
-    private readonly Context _context;
     private readonly DataService.DataServiceClient _dataServiceClient;
 
-    public IngestDataCommandHandler(Context context, DataService.DataServiceClient dataServiceClient)
+    public IngestDataCommandHandler(Context context, IPublishEndpoint publishEndpoint, DataService.DataServiceClient dataServiceClient) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
         _dataServiceClient = dataServiceClient ?? throw new ArgumentNullException(nameof(dataServiceClient));
     }
 
-    public async Task<DomainOperationResult> Handle(IngestDataCommand command, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(IngestDataCommand command, CancellationToken cancellationToken)
     {
         var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
         if (user is null)
@@ -50,5 +49,4 @@ public sealed class IngestDataCommandHandler : IRequestHandler<IngestDataCommand
             ? DomainOperationResult.Success
             : DomainOperationResult.Failure("Failed to ingest data.");
     }
-
 }

--- a/src/OStats.API/Commands/IngestDataCommandHandler.cs
+++ b/src/OStats.API/Commands/IngestDataCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class IngestDataCommandHandler : IRequestHandler<IngestDataCommand, DomainOperationResult>
+public sealed class IngestDataCommandHandler : IRequestHandler<IngestDataCommand, DomainOperationResult>
 {
     private readonly Context _context;
     private readonly DataService.DataServiceClient _dataServiceClient;

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class LinkProjectToDatasetCommand : IRequest<DomainOperationResult>
+public sealed class LinkProjectToDatasetCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class LinkProjectToDatasetCommand : IRequest<DomainOperationResult>
+public sealed record LinkProjectToDatasetCommand
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class LinkProjectToDatasetCommandHandler : IRequestHandler<LinkProjectToDatasetCommand, DomainOperationResult>
+public sealed class LinkProjectToDatasetCommandHandler : IRequestHandler<LinkProjectToDatasetCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class LinkProjectToDatasetCommandHandler : IRequestHandler<LinkProjectToDatasetCommand, DomainOperationResult>
+public sealed class LinkProjectToDatasetCommandHandler : CommandHandler<LinkProjectToDatasetCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public LinkProjectToDatasetCommandHandler(Context context)
+    public LinkProjectToDatasetCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(LinkProjectToDatasetCommand command, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(LinkProjectToDatasetCommand command, CancellationToken cancellationToken)
     {
         var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
         if (user is null)
@@ -40,7 +38,7 @@ public sealed class LinkProjectToDatasetCommandHandler : IRequestHandler<LinkPro
             return result;
         }
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return result;
     }

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class RemoveUserFromDatasetCommand : IRequest<DomainOperationResult>
+public sealed class RemoveUserFromDatasetCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; set; }
     public Guid DatasetId { get; set; }

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class RemoveUserFromDatasetCommand : IRequest<DomainOperationResult>
+public sealed record RemoveUserFromDatasetCommand
 {
     public string UserAuthId { get; set; }
     public Guid DatasetId { get; set; }

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class RemoveUserFromDatasetCommandHandler : IRequestHandler<RemoveUserFromDatasetCommand, DomainOperationResult>
+public sealed class RemoveUserFromDatasetCommandHandler : IRequestHandler<RemoveUserFromDatasetCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class RemoveUserFromDatasetCommandHandler : IRequestHandler<RemoveUserFromDatasetCommand, DomainOperationResult>
+public sealed class RemoveUserFromDatasetCommandHandler : CommandHandler<RemoveUserFromDatasetCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public RemoveUserFromDatasetCommandHandler(Context context)
+    public RemoveUserFromDatasetCommandHandler(Context contex, IPublishEndpoint publishEndpoint) : base(contex, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(RemoveUserFromDatasetCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(RemoveUserFromDatasetCommand request, CancellationToken cancellationToken)
     {
         var dataset = await _context.Datasets.FindAsync(request.DatasetId, cancellationToken);
         if (dataset is null)
@@ -33,7 +31,7 @@ public sealed class RemoveUserFromDatasetCommandHandler : IRequestHandler<Remove
             return result;
         }
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
         return result;
     }
 }

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class RemoveUserFromProjectCommand : IRequest<DomainOperationResult>
+public sealed class RemoveUserFromProjectCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; set; }
     public Guid ProjectId { get; set; }

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class RemoveUserFromProjectCommand : IRequest<DomainOperationResult>
+public sealed record RemoveUserFromProjectCommand
 {
     public string UserAuthId { get; set; }
     public Guid ProjectId { get; set; }

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class RemoveUserFromProjectCommandHandler : IRequestHandler<RemoveUserFromProjectCommand, DomainOperationResult>
+public sealed class RemoveUserFromProjectCommandHandler : IRequestHandler<RemoveUserFromProjectCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class RemoveUserFromProjectCommandHandler : IRequestHandler<RemoveUserFromProjectCommand, DomainOperationResult>
+public sealed class RemoveUserFromProjectCommandHandler : CommandHandler<RemoveUserFromProjectCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public RemoveUserFromProjectCommandHandler(Context context)
+    public RemoveUserFromProjectCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(RemoveUserFromProjectCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(RemoveUserFromProjectCommand request, CancellationToken cancellationToken)
     {
 
         var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
@@ -35,7 +33,7 @@ public sealed class RemoveUserFromProjectCommandHandler : IRequestHandler<Remove
             return result;
         }
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return result;
     }

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class UnlinkProjectToDatasetCommand : IRequest<DomainOperationResult>
+public sealed class UnlinkProjectToDatasetCommand : IRequest<DomainOperationResult>
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
@@ -1,9 +1,6 @@
-using MediatR;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class UnlinkProjectToDatasetCommand : IRequest<DomainOperationResult>
+public sealed record UnlinkProjectToDatasetCommand
 {
     public string UserAuthId { get; }
     public Guid DatasetId { get; }

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
@@ -4,7 +4,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class UnlinkProjectToDatasetCommandHandler : IRequestHandler<UnlinkProjectToDatasetCommand, DomainOperationResult>
+public sealed class UnlinkProjectToDatasetCommandHandler : IRequestHandler<UnlinkProjectToDatasetCommand, DomainOperationResult>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
@@ -1,19 +1,17 @@
-using MediatR;
+using MassTransit;
+using OStats.API.Commands.Common;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public sealed class UnlinkProjectToDatasetCommandHandler : IRequestHandler<UnlinkProjectToDatasetCommand, DomainOperationResult>
+public sealed class UnlinkProjectToDatasetCommandHandler : CommandHandler<UnlinkProjectToDatasetCommand, DomainOperationResult>
 {
-    private readonly Context _context;
-
-    public UnlinkProjectToDatasetCommandHandler(Context context)
+    public UnlinkProjectToDatasetCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<DomainOperationResult> Handle(UnlinkProjectToDatasetCommand command, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(UnlinkProjectToDatasetCommand command, CancellationToken cancellationToken)
     {
         var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
         if (user is null)
@@ -39,7 +37,7 @@ public sealed class UnlinkProjectToDatasetCommandHandler : IRequestHandler<Unlin
             return result;
         }
 
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return result;
     }

--- a/src/OStats.API/Commands/UpdateDatasetCommand.cs
+++ b/src/OStats.API/Commands/UpdateDatasetCommand.cs
@@ -1,10 +1,6 @@
-using MediatR;
-using OStats.API.Dtos;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class UpdateDatasetCommand : CreateDatasetCommand, IRequest<ValueTuple<DomainOperationResult, BaseDatasetDto?>>
+public sealed record UpdateDatasetCommand : CreateDatasetCommand
 {
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }

--- a/src/OStats.API/Commands/UpdateDatasetCommand.cs
+++ b/src/OStats.API/Commands/UpdateDatasetCommand.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class UpdateDatasetCommand : CreateDatasetCommand, IRequest<ValueTuple<DomainOperationResult, BaseDatasetDto?>>
+public sealed class UpdateDatasetCommand : CreateDatasetCommand, IRequest<ValueTuple<DomainOperationResult, BaseDatasetDto?>>
 {
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }

--- a/src/OStats.API/Commands/UpdateDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateDatasetCommandHandler.cs
@@ -6,7 +6,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class UpdateDatasetCommandHandler : IRequestHandler<UpdateDatasetCommand, ValueTuple<DomainOperationResult, BaseDatasetDto?>>
+public sealed class UpdateDatasetCommandHandler : IRequestHandler<UpdateDatasetCommand, ValueTuple<DomainOperationResult, BaseDatasetDto?>>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Commands/UpdateProjectCommand.cs
+++ b/src/OStats.API/Commands/UpdateProjectCommand.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.API.Commands;
 
-public class UpdateProjectCommand : CreateProjectCommand, IRequest<ValueTuple<DomainOperationResult, BaseProjectDto?>>
+public sealed class UpdateProjectCommand : CreateProjectCommand, IRequest<ValueTuple<DomainOperationResult, BaseProjectDto?>>
 {
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }

--- a/src/OStats.API/Commands/UpdateProjectCommand.cs
+++ b/src/OStats.API/Commands/UpdateProjectCommand.cs
@@ -1,10 +1,6 @@
-using MediatR;
-using OStats.API.Dtos;
-using OStats.Domain.Common;
-
 namespace OStats.API.Commands;
 
-public sealed class UpdateProjectCommand : CreateProjectCommand, IRequest<ValueTuple<DomainOperationResult, BaseProjectDto?>>
+public sealed record UpdateProjectCommand : CreateProjectCommand
 {
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }

--- a/src/OStats.API/Commands/UpdateProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateProjectCommandHandler.cs
@@ -7,7 +7,7 @@ using OStats.Infrastructure;
 
 namespace OStats.API.Commands;
 
-public class UpdateProjectCommandHandler : IRequestHandler<UpdateProjectCommand, ValueTuple<DomainOperationResult, BaseProjectDto?>>
+public sealed class UpdateProjectCommandHandler : IRequestHandler<UpdateProjectCommand, ValueTuple<DomainOperationResult, BaseProjectDto?>>
 {
     private readonly Context _context;
 

--- a/src/OStats.API/Consumers/GrantedUserAccessToDatasetDomainEventConsumer.cs
+++ b/src/OStats.API/Consumers/GrantedUserAccessToDatasetDomainEventConsumer.cs
@@ -31,7 +31,7 @@ public class GrantedUserAccessToDatasetDomainEventConsumer : IConsumer<GrantedUs
             user?.Name ?? domainEvent.DatasetUserAccessLevel.UserId.ToString()
         );
 
-        var result = await _handler.Handle(new AddAggregateHistoryEntryCommand
+        await _handler.Handle(new AddAggregateHistoryEntryCommand
         {
             AggregateId = dataset?.Id ?? domainEvent.DatasetUserAccessLevel.DatasetId,
             AggregateType = nameof(Dataset),

--- a/src/OStats.API/Extensions/PublishEndpointExtensions.cs
+++ b/src/OStats.API/Extensions/PublishEndpointExtensions.cs
@@ -14,7 +14,7 @@ public static class PublishEndpointExtensions
     /// <param name="aggregateRoot">The aggregate root.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task PublishDomainEventsAsync(this IPublishEndpoint publishEndpoint, IAggregateRoot aggregateRoot, CancellationToken cancellationToken)
+    public static async Task PublishDomainEventsAsync(this IPublishEndpoint publishEndpoint, AggregateRoot aggregateRoot, CancellationToken cancellationToken)
     {
         if (!aggregateRoot.DomainEvents.Any())
         {

--- a/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
@@ -1,14 +1,32 @@
+using System.Reflection;
 using System.Security.Claims;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using OStats.API.Commands.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    public static IServiceCollection AddCommandHandlers(this IServiceCollection services)
+    {
+        var commandHandlerType = typeof(CommandHandler<,>);
+        var commandHandlerTypeImplementations = Assembly
+            .GetExecutingAssembly()
+            .GetTypes()
+            .Where(t => t.BaseType != null && t.BaseType.IsGenericType && t.BaseType.GetGenericTypeDefinition() == commandHandlerType);
+
+        foreach (var handler in commandHandlerTypeImplementations)
+        {
+            services.AddTransient(handler);
+        }
+
+        return services;
+    }
+
     public static IServiceCollection AddJwtBearerAuthentication(this IServiceCollection services)
     {
         services

--- a/src/OStats.API/OStats.API.csproj
+++ b/src/OStats.API/OStats.API.csproj
@@ -16,7 +16,6 @@
     </PackageReference>
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
-    <PackageReference Include="MediatR" Version="12.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />

--- a/src/OStats.API/Program.cs
+++ b/src/OStats.API/Program.cs
@@ -15,10 +15,7 @@ builder.Services.AddGrpcClient<DataService.DataServiceClient>(o =>
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwagger();
-builder.Services.AddMediatR(cfg =>
-{
-    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
-});
+builder.Services.AddCommandHandlers();
 builder.Services.AddMessageBroker();
 
 var app = builder.Build();

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
@@ -3,16 +3,13 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.DatasetAggregate;
 
-public class Dataset : Entity, IAggregateRoot
+public class Dataset : AggregateRoot
 {
     public string Title { get; set; }
     public string Source { get; set; }
     public string? Description { get; set; }
     private readonly List<DatasetUserAccessLevel> _datasetUsersAccessesLevels = new List<DatasetUserAccessLevel>();
     public IReadOnlyCollection<DatasetUserAccessLevel> DatasetUserAccessLevels => _datasetUsersAccessesLevels;
-
-    private readonly List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
-    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
     private Dataset(string title, string source)
     {

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.DatasetAggregate;
 
-public class Dataset : AggregateRoot
+public sealed class Dataset : AggregateRoot
 {
     public string Title { get; set; }
     public string Source { get; set; }

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/DatasetUserAccessLevel.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/DatasetUserAccessLevel.cs
@@ -2,7 +2,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.DatasetAggregate;
 
-public class DatasetUserAccessLevel : Entity
+public sealed class DatasetUserAccessLevel : Entity
 {
     public Guid DatasetId { get; }
     public Guid UserId { get; }

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Events/GrantedUserAccessToDatasetDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Events/GrantedUserAccessToDatasetDomainEvent.cs
@@ -2,7 +2,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.DatasetAggregate;
 
-public record GrantedUserAccessToDatasetDomainEvent : IDomainEvent
+public sealed record GrantedUserAccessToDatasetDomainEvent : IDomainEvent
 {
     public DatasetUserAccessLevel DatasetUserAccessLevel { get; init; }
     public Guid RequestorId { get; init; }

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Events/RevokedUserAccessFromDatasetDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Events/RevokedUserAccessFromDatasetDomainEvent.cs
@@ -2,7 +2,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.DatasetAggregate;
 
-public class RevokedUserAccessFromDatasetDomainEvent : IDomainEvent
+public sealed class RevokedUserAccessFromDatasetDomainEvent : IDomainEvent
 {
     public DatasetUserAccessLevel DatasetUserAccessLevel { get; init; }
     public Guid RequestorId { get; init; }

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/DatasetProjectLink.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/DatasetProjectLink.cs
@@ -2,7 +2,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate;
 
-public class DatasetProjectLink : Entity
+public sealed class DatasetProjectLink : Entity
 {
     public Guid DatasetId { get; }
     public Guid ProjectId { get; }

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate;
 
-public class Project : AggregateRoot
+public sealed class Project : AggregateRoot
 {
     public string Title { get; set; }
     public string? Description { get; set; }

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate;
 
-public class Project : Entity, IAggregateRoot
+public class Project : AggregateRoot
 {
     public string Title { get; set; }
     public string? Description { get; set; }
@@ -11,8 +11,6 @@ public class Project : Entity, IAggregateRoot
     public IReadOnlyCollection<Role> Roles => _roles;
     private readonly HashSet<DatasetProjectLink> _linkedDatasets = new HashSet<DatasetProjectLink>();
     public IReadOnlyCollection<DatasetProjectLink> LinkedDatasets => _linkedDatasets;
-    private readonly List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
-    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
     private Project(string title, string? description = null)
     {

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Role.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Role.cs
@@ -2,7 +2,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate;
 
-public class Role : Entity
+public sealed class Role : Entity
 {
     public Guid ProjectId { get; }
     public Guid UserId { get; }

--- a/src/OStats.Domain/Aggregates/UserAggregate/User.cs
+++ b/src/OStats.Domain/Aggregates/UserAggregate/User.cs
@@ -3,13 +3,11 @@ using OStats.Domain.Common;
 namespace OStats.Domain.Aggregates.UserAggregate;
 
 
-public class User : Entity, IAggregateRoot
+public class User : AggregateRoot
 {
     public string Name { get; private set; }
     public string Email { get; private set; }
     public string AuthIdentity { get; private set; }
-    private readonly List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
-    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
     public User(string name, string email, string authIdentity)
     {
         Name = name;

--- a/src/OStats.Domain/Aggregates/UserAggregate/User.cs
+++ b/src/OStats.Domain/Aggregates/UserAggregate/User.cs
@@ -3,7 +3,7 @@ using OStats.Domain.Common;
 namespace OStats.Domain.Aggregates.UserAggregate;
 
 
-public class User : AggregateRoot
+public sealed class User : AggregateRoot
 {
     public string Name { get; private set; }
     public string Email { get; private set; }

--- a/src/OStats.Domain/Common/AggregateRoot.cs
+++ b/src/OStats.Domain/Common/AggregateRoot.cs
@@ -1,0 +1,7 @@
+namespace OStats.Domain.Common;
+
+public abstract class AggregateRoot : Entity
+{
+    private protected readonly List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+}

--- a/src/OStats.Domain/Common/IAggregateRoot.cs
+++ b/src/OStats.Domain/Common/IAggregateRoot.cs
@@ -1,6 +1,0 @@
-namespace OStats.Domain.Common;
-
-public interface IAggregateRoot
-{
-    IReadOnlyCollection<IDomainEvent> DomainEvents { get; }
-}

--- a/src/OStats.Infrastructure/Context.cs
+++ b/src/OStats.Infrastructure/Context.cs
@@ -8,7 +8,7 @@ using OStats.Infrastructure.EntitiesConfiguration;
 
 namespace OStats.Infrastructure;
 
-public class Context : DbContext
+public sealed class Context : DbContext
 {
     // DatasetAggregate db sets
     public DbSet<Dataset> Datasets { get; set; }

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/AggregateHistoryEntryConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/AggregateHistoryEntryConfiguration.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Common;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-public class AggregateHistoryEntryConfiguration : IEntityTypeConfiguration<AggregateHistoryEntry>
+sealed class AggregateHistoryEntryConfiguration : IEntityTypeConfiguration<AggregateHistoryEntry>
 {
     public void Configure(EntityTypeBuilder<AggregateHistoryEntry> builder)
     {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetEntityConfiguration.cs
@@ -5,7 +5,7 @@ using OStats.Domain.Aggregates.ProjectAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class DatasetEntityConfiguration : EntityConfiguration<Dataset>, IEntityTypeConfiguration<Dataset>
+sealed class DatasetEntityConfiguration : EntityConfiguration<Dataset>, IEntityTypeConfiguration<Dataset>
 {
        public void Configure(EntityTypeBuilder<Dataset> builder)
        {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetProjectLinkEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetProjectLinkEntityConfiguration.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Aggregates.ProjectAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class DatasetProjectLinkConfiguration : EntityConfiguration<DatasetProjectLink>, IEntityTypeConfiguration<DatasetProjectLink>
+sealed class DatasetProjectLinkConfiguration : EntityConfiguration<DatasetProjectLink>, IEntityTypeConfiguration<DatasetProjectLink>
 {
     public void Configure(EntityTypeBuilder<DatasetProjectLink> builder)
     {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetUserAccessLevelEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/DatasetUserAccessLevelEntityConfiguration.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Aggregates.DatasetAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class DatasetUserAccessLevelEntityConfiguration : EntityConfiguration<DatasetUserAccessLevel>, IEntityTypeConfiguration<DatasetUserAccessLevel>
+sealed class DatasetUserAccessLevelEntityConfiguration : EntityConfiguration<DatasetUserAccessLevel>, IEntityTypeConfiguration<DatasetUserAccessLevel>
 {
     public void Configure(EntityTypeBuilder<DatasetUserAccessLevel> builder)
     {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/ProjectEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/ProjectEntityConfiguration.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Aggregates.ProjectAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class ProjectEntityConfiguration : EntityConfiguration<Project>, IEntityTypeConfiguration<Project>
+sealed class ProjectEntityConfiguration : EntityConfiguration<Project>, IEntityTypeConfiguration<Project>
 {
        public void Configure(EntityTypeBuilder<Project> builder)
        {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/RoleEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/RoleEntityConfiguration.cs
@@ -4,7 +4,7 @@ using OStats.Domain.Aggregates.ProjectAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class RoleEntityConfiguration : EntityConfiguration<Role>, IEntityTypeConfiguration<Role>
+sealed class RoleEntityConfiguration : EntityConfiguration<Role>, IEntityTypeConfiguration<Role>
 {
     public void Configure(EntityTypeBuilder<Role> builder)
     {

--- a/src/OStats.Infrastructure/EntitiesConfiguration.cs/UserEntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration.cs/UserEntityConfiguration.cs
@@ -6,7 +6,7 @@ using OStats.Domain.Aggregates.UserAggregate;
 
 namespace OStats.Infrastructure.EntitiesConfiguration;
 
-class UserEntityConfiguration : EntityConfiguration<User>, IEntityTypeConfiguration<User>
+sealed class UserEntityConfiguration : EntityConfiguration<User>, IEntityTypeConfiguration<User>
 {
     public void Configure(EntityTypeBuilder<User> builder)
     {

--- a/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
+++ b/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using OStats.Domain.Common;
+
+namespace OStats.Infrastructure.Extensions;
+public static class ChangeTrackerExtensions
+{
+    public static IEnumerable<IDomainEvent>? GetAggregateRootDomainEvents(this ChangeTracker changeTracker)
+    {
+        if (changeTracker.HasChanges())
+        {
+            return changeTracker
+                .Entries<IAggregateRoot>()
+                .Where(entry => entry.Entity.DomainEvents.Count != 0)
+                .SelectMany(entry => entry.Entity.DomainEvents);
+        }
+
+        return null;
+    }
+}

--- a/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
+++ b/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
@@ -4,16 +4,11 @@ using OStats.Domain.Common;
 namespace OStats.Infrastructure.Extensions;
 public static class ChangeTrackerExtensions
 {
-    public static IEnumerable<IDomainEvent>? GetAggregateRootDomainEvents(this ChangeTracker changeTracker)
+    public static IEnumerable<IDomainEvent> GetAggregateRootDomainEvents(this ChangeTracker changeTracker)
     {
-        if (changeTracker.HasChanges())
-        {
-            return changeTracker
-                .Entries<AggregateRoot>()
-                .Where(entry => entry.Entity.DomainEvents.Count != 0)
-                .SelectMany(entry => entry.Entity.DomainEvents);
-        }
-
-        return null;
+        return changeTracker
+            .Entries<AggregateRoot>()
+            .Where(entry => entry.Entity.DomainEvents.Count != 0)
+            .SelectMany(entry => entry.Entity.DomainEvents ?? Enumerable.Empty<IDomainEvent>());
     }
 }

--- a/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
+++ b/src/OStats.Infrastructure/Extensions/ChangeTrackerExtensions.cs
@@ -9,7 +9,7 @@ public static class ChangeTrackerExtensions
         if (changeTracker.HasChanges())
         {
             return changeTracker
-                .Entries<IAggregateRoot>()
+                .Entries<AggregateRoot>()
                 .Where(entry => entry.Entity.DomainEvents.Count != 0)
                 .SelectMany(entry => entry.Entity.DomainEvents);
         }

--- a/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
@@ -1,5 +1,4 @@
 using MassTransit.Testing;
-using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OStats.Domain.Aggregates.DatasetAggregate;
@@ -12,15 +11,15 @@ namespace OStats.Tests.IntegrationTests;
 public abstract class BaseIntegrationTest : IClassFixture<IntegrationTestWebAppFactory>, IDisposable
 {
     private readonly IServiceScope _scope;
-    protected readonly ISender sender;
     protected readonly Context context;
+    protected readonly IServiceProvider serviceProvider;
     protected readonly HttpClient client;
     protected readonly ITestHarness queueHarness;
 
     protected BaseIntegrationTest(IntegrationTestWebAppFactory factory)
     {
         _scope = factory.Services.CreateScope();
-        sender = _scope.ServiceProvider.GetRequiredService<ISender>();
+        serviceProvider = _scope.ServiceProvider;
         context = _scope.ServiceProvider.GetRequiredService<Context>();
         queueHarness = _scope.ServiceProvider.GetTestHarness();
         client = factory.CreateClient();

--- a/src/OStats.Tests/IntegrationTests/Commands/AddAggregateHistoryEntryCommandIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/AddAggregateHistoryEntryCommandIntegrationTest.cs
@@ -1,38 +1,36 @@
 using FluentAssertions.Execution;
 using MassTransit.Testing;
 using Microsoft.EntityFrameworkCore;
-using OStats.API.Commands;
 using OStats.API.Consumers;
 using OStats.Domain.Aggregates.DatasetAggregate;
 
-namespace OStats.Tests.IntegrationTests.Commands
+namespace OStats.Tests.IntegrationTests.Commands;
+
+public class AddAggregateHistoryEntryCommandIntegrationTest : BaseIntegrationTest
 {
-    public class AddAggregateHistoryEntryCommandIntegrationTest : BaseIntegrationTest
+    public AddAggregateHistoryEntryCommandIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
     {
-        public AddAggregateHistoryEntryCommandIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
+    }
+
+    [Fact]
+    public async Task Should_Add_History_Entry()
+    {
+        var dataset = await context.Datasets.FirstAsync();
+        var consumerHarness = queueHarness.GetConsumerHarness<GrantedUserAccessToDatasetDomainEventConsumer>();
+
+        var message = new GrantedUserAccessToDatasetDomainEvent
+        (
+            new DatasetUserAccessLevel(dataset.Id, Guid.NewGuid(), DatasetAccessLevel.ReadOnly),
+            Guid.NewGuid()
+        );
+        await queueHarness.Bus.Publish(message);
+
+        await Task.Delay(5 * 1000);
+
+        using (new AssertionScope())
         {
-        }
-
-        [Fact]
-        public async Task Should_Add_History_Entry()
-        {
-            var dataset = await context.Datasets.FirstAsync();
-            var consumerHarness = queueHarness.GetConsumerHarness<GrantedUserAccessToDatasetDomainEventConsumer>();
-
-            var message = new GrantedUserAccessToDatasetDomainEvent
-            (
-                new DatasetUserAccessLevel(dataset.Id, Guid.NewGuid(), DatasetAccessLevel.ReadOnly),
-                Guid.NewGuid()
-            );
-            await queueHarness.Bus.Publish(message);
-
-            await Task.Delay(5 * 1000);
-
-            using (new AssertionScope())
-            {
-                var consumed = await consumerHarness.Consumed.SelectAsync<GrantedUserAccessToDatasetDomainEvent>().Any();
-                consumed.Should().BeTrue();
-            }
+            var consumed = await consumerHarness.Consumed.SelectAsync<GrantedUserAccessToDatasetDomainEvent>().Any();
+            consumed.Should().BeTrue();
         }
     }
 }

--- a/src/OStats.Tests/IntegrationTests/Commands/AddAggregateHistoryEntryCommandIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/AddAggregateHistoryEntryCommandIntegrationTest.cs
@@ -2,6 +2,8 @@ using FluentAssertions.Execution;
 using MassTransit.Testing;
 using Microsoft.EntityFrameworkCore;
 using OStats.API.Commands;
+using OStats.API.Consumers;
+using OStats.Domain.Aggregates.DatasetAggregate;
 
 namespace OStats.Tests.IntegrationTests.Commands
 {
@@ -15,35 +17,21 @@ namespace OStats.Tests.IntegrationTests.Commands
         public async Task Should_Add_History_Entry()
         {
             var dataset = await context.Datasets.FirstAsync();
-            var consumerHarness = queueHarness.GetConsumerHarness<AddAggregateHistoryEntryCommandHandler>();
+            var consumerHarness = queueHarness.GetConsumerHarness<GrantedUserAccessToDatasetDomainEventConsumer>();
 
-            AddAggregateHistoryEntryCommand message = new AddAggregateHistoryEntryCommand
-            {
-                AggregateId = dataset.Id,
-                AggregateType = dataset.GetType().Name,
-                UserId = Guid.NewGuid(),
-                EventType = "Test",
-                EventData = "Test",
-                EventDescription = "Test",
-                TimeStamp = DateTime.UtcNow
-            };
+            var message = new GrantedUserAccessToDatasetDomainEvent
+            (
+                new DatasetUserAccessLevel(dataset.Id, Guid.NewGuid(), DatasetAccessLevel.ReadOnly),
+                Guid.NewGuid()
+            );
             await queueHarness.Bus.Publish(message);
 
             await Task.Delay(5 * 1000);
 
             using (new AssertionScope())
             {
-                var consumed = await consumerHarness.Consumed.SelectAsync<AddAggregateHistoryEntryCommand>().Any();
+                var consumed = await consumerHarness.Consumed.SelectAsync<GrantedUserAccessToDatasetDomainEvent>().Any();
                 consumed.Should().BeTrue();
-
-                var historyEntry = await context.AggregatesHistoryEntries.Where(entry => entry.AggregateId == dataset.Id).SingleAsync();
-                historyEntry.Should().NotBeNull();
-                historyEntry.AggregateId.Should().Be(message.AggregateId);
-                historyEntry.AggregateType.Should().Be(message.AggregateType);
-                historyEntry.UserId.Should().Be(message.UserId);
-                historyEntry.EventType.Should().Be(message.EventType);
-                historyEntry.EventData.Should().Be(message.EventData);
-                historyEntry.EventDescription.Should().Be(message.EventDescription);
             }
         }
     }

--- a/src/OStats.Tests/IntegrationTests/Commands/AddUserToProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/AddUserToProjectIntegrationTest.cs
@@ -1,5 +1,6 @@
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using OStats.API.Commands;
 using OStats.Domain.Aggregates.ProjectAggregate;
 using OStats.Domain.Aggregates.UserAggregate;
@@ -24,7 +25,7 @@ public class AddUserToProjectIntegrationTest : BaseIntegrationTest
         var access = AccessLevel.ReadOnly;
 
         var command = new AddUserToProjectCommand(owner.AuthIdentity, project.Id, user.Id, access);
-        var result = await sender.Send(command);
+        var result = await serviceProvider.GetRequiredService<AddUserToProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
         {

--- a/src/OStats.Tests/IntegrationTests/Commands/CreateUserIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/CreateUserIntegrationTest.cs
@@ -1,5 +1,6 @@
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using OStats.API.Commands;
 using OStats.API.Dtos;
 
@@ -16,7 +17,7 @@ public class CreateUserIntegrationTest : BaseIntegrationTest
     {
         var beforeCommandTime = DateTime.UtcNow;
         var command = new CreateUserCommand("Test", "test@test.com", "auth_id_string");
-        var (result, baseUserDto) = await sender.Send(command);
+        var (result, baseUserDto) = await serviceProvider.GetRequiredService<CreateUserCommandHandler>().Handle(command, default);
         var afterCommandTime = DateTime.UtcNow;
 
         using (new AssertionScope())
@@ -25,7 +26,7 @@ public class CreateUserIntegrationTest : BaseIntegrationTest
             result.ErrorMessage.Should().BeNull();
 
             baseUserDto.Should().NotBeNull().And.BeOfType<BaseUserDto>();
-            baseUserDto.CreatedAt.Should().BeAfter(beforeCommandTime).And.BeBefore(afterCommandTime);
+            baseUserDto!.CreatedAt.Should().BeAfter(beforeCommandTime).And.BeBefore(afterCommandTime);
             baseUserDto.LastUpdatedAt.Should().BeAfter(beforeCommandTime).And.BeBefore(afterCommandTime);
         }
     }
@@ -35,7 +36,7 @@ public class CreateUserIntegrationTest : BaseIntegrationTest
     {
         var existingUser = await context.Users.FirstAsync();
         var command = new CreateUserCommand("Test", "test@test.com", existingUser.AuthIdentity);
-        var (result, baseUserDto) = await sender.Send(command);
+        var (result, baseUserDto) = await serviceProvider.GetRequiredService<CreateUserCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
         {

--- a/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
@@ -1,5 +1,6 @@
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using OStats.API.Commands;
 using OStats.Domain.Aggregates.ProjectAggregate;
 using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
@@ -23,7 +24,7 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
         project.AddOrUpdateUserRole(user.Id, AccessLevel.Editor, ownerId);
         await context.SaveChangesAsync();
         var command = new DeleteProjectCommand(user.AuthIdentity, project.Id);
-        var result = await sender.Send(command);
+        var result = await serviceProvider.GetRequiredService<DeleteProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
         {
@@ -41,7 +42,7 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
         context.SaveChanges();
 
         var command = new DeleteProjectCommand(existingUser.AuthIdentity, project.Id);
-        var result = await sender.Send(command);
+        var result = await serviceProvider.GetRequiredService<DeleteProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
         {


### PR DESCRIPTION
This pull request focuses on refactoring the command handling mechanism by removing the `MediatR` library and directly using specific command handlers. Additionally, it introduces a base `CommandHandler` class to streamline the command handling process.

### Refactoring Command Handling

* [`src/OStats.API/Apis/DatasetsApi.cs`](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL38-R41): Replaced `IMediator` with specific command handlers for dataset-related operations. [[1]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL38-R41) [[2]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL67-R96) [[3]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL156-R172)
* [`src/OStats.API/Apis/ProjectsApi.cs`](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L33-R37): Replaced `IMediator` with specific command handlers for project-related operations. [[1]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L33-R37) [[2]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L63-R79) [[3]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L104-R148)
* [`src/OStats.API/Apis/UsersApi.cs`](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L38-R37): Replaced `IMediator` with specific command handlers for user-related operations. [[1]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L38-R37) [[2]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L50-R49)

### Introducing Base Command Handler

* [`src/OStats.API/Commands/AddAggregateHistoryEntryCommandHandler.cs`](diffhunk://#diff-f1696b8dee4217ae5c31f2c18f1b4b49c7fd970ccb9926d40ee2b5ff0575ca00R2-L18): Introduced a base `CommandHandler` class and updated the `AddAggregateHistoryEntryCommandHandler` to inherit from it. [[1]](diffhunk://#diff-f1696b8dee4217ae5c31f2c18f1b4b49c7fd970ccb9926d40ee2b5ff0575ca00R2-L18) [[2]](diffhunk://#diff-f1696b8dee4217ae5c31f2c18f1b4b49c7fd970ccb9926d40ee2b5ff0575ca00L28-R28)
* [`src/OStats.API/Commands/AddUserToDatasetCommandHandler.cs`](diffhunk://#diff-0e671cfe6ca510c471ab8bbdbd3cc60e86721632fd9e18842d20370302e3086cL2-R40): Updated to inherit from the new `CommandHandler` class.
* [`src/OStats.API/Commands/AddUserToProjectCommandHandler.cs`](diffhunk://#diff-a69dd6de1a8eb55d477184dd0d4bb0a08bd535f28079c55b56dc2b9a0cc61539L1-R14): Updated to inherit from the new `CommandHandler` class. [[1]](diffhunk://#diff-a69dd6de1a8eb55d477184dd0d4bb0a08bd535f28079c55b56dc2b9a0cc61539L1-R14) [[2]](diffhunk://#diff-a69dd6de1a8eb55d477184dd0d4bb0a08bd535f28079c55b56dc2b9a0cc61539L36-R34)

### Code Cleanup

* Removed `MediatR` references from various files, including `src/OStats.API/Apis/DatasetsApi.cs`, `src/OStats.API/Apis/ProjectsApi.cs`, and `src/OStats.API/Apis/UsersApi.cs`. [[1]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL4-L7) [[2]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L1) [[3]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L1)
* Updated command classes to use `sealed record` instead of `class`. [[1]](diffhunk://#diff-8dc42dc429b20fed2dfb8d7a4b0192fe271acd61ce58a8c25664854ec68afcd4L3-R3) [[2]](diffhunk://#diff-59bb4a02229a914e093b3a054c443d8229279268eb6e206ac9d1e279f7c1dddeL1-R5) [[3]](diffhunk://#diff-01bf76616f7f12172cf786fc0471468f38654e3816be05e911b74bcb4c76fb34L1-R5)

These changes improve the codebase by reducing dependencies and making the command handling process more explicit and maintainable.