### PR TITLE
feat: add dataset visibility

### DIFF
--- a/src/OStats.API/Commands/UpdateDatasetVisibilityCommand.cs
+++ b/src/OStats.API/Commands/UpdateDatasetVisibilityCommand.cs
@@ -1,0 +1,8 @@
+namespace OStats.API.Commands;
+
+public sealed record UpdateDatasetVisibilityCommand
+{
+    public required Guid DatasetId { get; init; }
+    public required string UserAuthId { get; init; }
+    public required bool IsPublic { get; init; }
+}

--- a/src/OStats.API/Commands/UpdateDatasetVisibilityCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateDatasetVisibilityCommandHandler.cs
@@ -1,0 +1,37 @@
+using MassTransit;
+using OStats.API.Commands.Common;
+using OStats.Domain.Common;
+using OStats.Infrastructure;
+
+namespace OStats.API.Commands;
+
+public sealed class UpdateDatasetVisibilityCommandHandler : CommandHandler<UpdateDatasetVisibilityCommand, DomainOperationResult>
+{
+    public UpdateDatasetVisibilityCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
+    {
+    }
+
+    public override async Task<DomainOperationResult> Handle(UpdateDatasetVisibilityCommand request, CancellationToken cancellationToken)
+    {
+        var dataset = await _context.Datasets.FindAsync(request.DatasetId, cancellationToken);
+        if (dataset is null)
+        {
+            return DomainOperationResult.Failure("Dataset not found.");
+        }
+
+        var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
+        if (requestor is null)
+        {
+            return DomainOperationResult.Failure("Requestor not found.");
+        }
+
+        var result = dataset.UpdateVisibility(requestor.Id, request.IsPublic);
+        if (!result.Succeeded)
+        {
+            return result;
+        }
+
+        await SaveCommandHandlerChangesAsync(cancellationToken);
+        return result;
+    }
+}

--- a/src/OStats.API/Dtos/BaseDatasetDto.cs
+++ b/src/OStats.API/Dtos/BaseDatasetDto.cs
@@ -8,19 +8,22 @@ public record BaseDatasetDto : BaseEntityDto
     public string Title { get; }
     public string Source { get; }
     public string? Description { get; }
+    public bool IsPublic { get; }
 
     public BaseDatasetDto(Dataset dataset) : base(dataset)
     {
         Title = dataset.Title;
         Source = dataset.Source;
         Description = dataset.Description;
+        IsPublic = dataset.IsPublic;
     }
 
     [JsonConstructor]
-    public BaseDatasetDto(Guid id, DateTime createdAt, DateTime lastUpdatedAt, string title, string source, string? description) : base(id, createdAt, lastUpdatedAt)
+    public BaseDatasetDto(Guid id, DateTime createdAt, DateTime lastUpdatedAt, string title, string source, bool isPublic, string? description) : base(id, createdAt, lastUpdatedAt)
     {
         Title = title;
         Source = source;
         Description = description;
+        IsPublic = isPublic;
     }
 }

--- a/src/OStats.API/Dtos/DatasetWithUsersDto.cs
+++ b/src/OStats.API/Dtos/DatasetWithUsersDto.cs
@@ -9,7 +9,7 @@ public record DatasetWithUsersDto : BaseDatasetDto
     public List<DatasetUserAccessLevelsDto> DatasetUserAccessLevels { get; init; }
 
     [JsonConstructor]
-    public DatasetWithUsersDto(Dataset dataset, List<User> users) : base(dataset.Id, dataset.CreatedAt, dataset.LastUpdatedAt, dataset.Title, dataset.Source, dataset.Description)
+    public DatasetWithUsersDto(Dataset dataset, List<User> users) : base(dataset)
     {
         DatasetUserAccessLevels = GetUserAccessLevelDto(dataset, users);
     }

--- a/src/OStats.API/Dtos/UpdateDatasetVisibilityDto.cs
+++ b/src/OStats.API/Dtos/UpdateDatasetVisibilityDto.cs
@@ -1,0 +1,3 @@
+namespace OStats.API.Dtos;
+
+public sealed record UpdateDatasetVisibilityDto(bool IsPublic);

--- a/src/OStats.API/OStats.API.csproj
+++ b/src/OStats.API/OStats.API.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Events/UpdatedDatasetVisibilityDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Events/UpdatedDatasetVisibilityDomainEvent.cs
@@ -1,0 +1,10 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.DatasetAggregate.Events;
+
+public sealed record UpdatedDatasetVisibilityDomainEvent(
+    Guid DatasetId,
+    bool IsPublic,
+    Guid UserId) : IDomainEvent
+{
+}

--- a/src/OStats.Infrastructure/Migrations/20241102132249_AddDatasetVisibility.Designer.cs
+++ b/src/OStats.Infrastructure/Migrations/20241102132249_AddDatasetVisibility.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OStats.Infrastructure;
@@ -11,9 +12,11 @@ using OStats.Infrastructure;
 namespace OStats.Infrastructure.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20241102132249_AddDatasetVisibility")]
+    partial class AddDatasetVisibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OStats.Infrastructure/Migrations/20241102132249_AddDatasetVisibility.cs
+++ b/src/OStats.Infrastructure/Migrations/20241102132249_AddDatasetVisibility.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OStats.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDatasetVisibility : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublic",
+                table: "Datasets",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPublic",
+                table: "Datasets");
+        }
+    }
+}

--- a/src/OStats.Tests/UnitTests/Domain/Aggregates/DatasetAggregate/DatasetTests.cs
+++ b/src/OStats.Tests/UnitTests/Domain/Aggregates/DatasetAggregate/DatasetTests.cs
@@ -1,0 +1,62 @@
+using OStats.Domain.Aggregates.DatasetAggregate;
+
+namespace OStats.Tests.UnitTests.Domain.Aggregates.DatasetAggregate;
+
+public class DatasetTests
+{
+    [Fact]
+    public void Should_Be_Able_To_Add_Users_Roles()
+    {
+        var ownerId = Guid.NewGuid();
+        var dataset = new Dataset(ownerId, "Test Title", "Test Description");
+        var userId = Guid.NewGuid();
+        var accessLevel = DatasetAccessLevel.Editor;
+
+        var result = dataset.GrantUserAccess(userId, accessLevel, ownerId);
+
+        result.Succeeded.Should().BeTrue();
+        dataset.DatasetUserAccessLevels
+            .Single(role => role.UserId == userId && role.AccessLevel == accessLevel)
+            .Should()
+            .NotBeNull();
+    }
+
+    [Fact]
+    public void Should_Be_Able_To_Update_Dataset_Visibility()
+    {
+        var ownerId = Guid.NewGuid();
+        var dataset = new Dataset(ownerId, "Test Title", "Test Description");
+        var isPublic = !dataset.IsPublic;
+
+        var result = dataset.UpdateVisibility(ownerId, isPublic);
+
+        result.Succeeded.Should().BeTrue();
+        dataset.IsPublic.Should().Be(isPublic);
+    }
+
+    [Fact]
+    public void Should_Not_Be_Able_To_Update_Dataset_Visibility_If_Not_At_Least_Administrator()
+    {
+        var ownerId = Guid.NewGuid();
+        var dataset = new Dataset(ownerId, "Test Title", "Test Description");
+        var isPublic = !dataset.IsPublic;
+
+        var result = dataset.UpdateVisibility(Guid.NewGuid(), isPublic);
+
+        result.Succeeded.Should().BeFalse();
+        dataset.IsPublic.Should().Be(!isPublic);
+    }
+
+    [Fact]
+    public void Should_Take_No_Action_If_Visibility_Already_Set()
+    {
+        var ownerId = Guid.NewGuid();
+        var dataset = new Dataset(ownerId, "Test Title", "Test Description");
+        var isPublic = dataset.IsPublic;
+
+        var result = dataset.UpdateVisibility(ownerId, isPublic);
+
+        result.Succeeded.Should().BeFalse();
+        dataset.IsPublic.Should().Be(isPublic);
+    }
+}


### PR DESCRIPTION
This pull request introduces functionality to update the visibility of datasets within the `OStats` API. The changes include adding new endpoints, commands, DTOs, and tests to support this feature.

### New Functionality:

* **Endpoint Addition:**
  * Added a new endpoint to update dataset visibility (`src/OStats.API/Apis/DatasetsApi.cs`).

* **Command and Handler:**
  * Introduced `UpdateDatasetVisibilityCommand` and its handler to process visibility updates (`src/OStats.API/Commands/UpdateDatasetVisibilityCommand.cs`, `src/OStats.API/Commands/UpdateDatasetVisibilityCommandHandler.cs`). [[1]](diffhunk://#diff-d4f8774db6fbd47e095d03d452e948437e135f48f90320d6df8fadac148451f4R1-R8) [[2]](diffhunk://#diff-c0d517f09962b43debf3365df5be23485f683c44c23b0101a7246debc361e87dR1-R37)

* **Domain Changes:**
  * Added `IsPublic` property to the `Dataset` entity and implemented the `UpdateVisibility` method to handle visibility changes (`src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs`). [[1]](diffhunk://#diff-641f2d9442ea5cbc8388f2c59e2cf9df5226a8221fc8ee97e39e8cbaa6dadccfR12) [[2]](diffhunk://#diff-641f2d9442ea5cbc8388f2c59e2cf9df5226a8221fc8ee97e39e8cbaa6dadccfR82-R99)
  * Created `UpdatedDatasetVisibilityDomainEvent` to capture visibility change events (`src/OStats.Domain/Aggregates/DatasetAggregate/Events/UpdatedDatasetVisibilityDomainEvent.cs`).

### DTO and Migration Updates:

* **DTO Adjustments:**
  * Updated `BaseDatasetDto` and `DatasetWithUsersDto` to include the `IsPublic` property (`src/OStats.API/Dtos/BaseDatasetDto.cs`, `src/OStats.API/Dtos/DatasetWithUsersDto.cs`). [[1]](diffhunk://#diff-e079a83065b2e3fde13a49532c9039b0a2c6b60c120f68def31f4ab937d1c5e1R11-R27) [[2]](diffhunk://#diff-4ac68f431ff22692164e5df117e90d7806b81573a1bba7f23faf661e163b40beL12-R12)
  * Added `UpdateDatasetVisibilityDto` for visibility update requests (`src/OStats.API/Dtos/UpdateDatasetVisibilityDto.cs`).

* **Database Migration:**
  * Added a migration to include the `IsPublic` column in the `Datasets` table (`src/OStats.Infrastructure/Migrations/20241102132249_AddDatasetVisibility.cs`, `src/OStats.Infrastructure/Migrations/ContextModelSnapshot.cs`). [[1]](diffhunk://#diff-1aabe2d7ed5ccb8b1c32bc9aeac0ee3fdf96dcf8d2481e7ce4afb6826e853bf9R1-R29) [[2]](diffhunk://#diff-5a7a6787903ca97f75fd46c8e49dd0f4fef942a365bd9a29686b59cb6bd892bfR208-R210)

### Testing:

* **Integration Tests:**
  * Added an integration test to verify the dataset visibility update functionality (`src/OStats.Tests/IntegrationTests/Apis/DatasetsApiIntegrationTest.cs`).

* **Unit Tests:**
  * Added unit tests for the `Dataset` entity to ensure correct behavior of visibility updates (`src/OStats.Tests/UnitTests/Domain/Aggregates/DatasetAggregate/DatasetTests.cs`).