### PR TITLE
refactor: replace List initialization with array syntax in domain mod…

### DIFF
--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
@@ -10,7 +10,7 @@ public sealed class Dataset : AggregateRoot
     public string Source { get; set; }
     public string? Description { get; set; }
     public bool IsPublic { get; private set; }
-    private readonly List<DatasetUserAccessLevel> _datasetUsersAccessesLevels = new List<DatasetUserAccessLevel>();
+    private readonly List<DatasetUserAccessLevel> _datasetUsersAccessesLevels = [];
     public IReadOnlyCollection<DatasetUserAccessLevel> DatasetUserAccessLevels => _datasetUsersAccessesLevels;
 
     private Dataset(string title, string source)

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -7,9 +7,9 @@ public sealed class Project : AggregateRoot
 {
     public string Title { get; set; }
     public string? Description { get; set; }
-    private readonly List<Role> _roles = new List<Role>();
+    private readonly List<Role> _roles = [];
     public IReadOnlyCollection<Role> Roles => _roles;
-    private readonly HashSet<DatasetProjectLink> _linkedDatasets = new HashSet<DatasetProjectLink>();
+    private readonly HashSet<DatasetProjectLink> _linkedDatasets = [];
     public IReadOnlyCollection<DatasetProjectLink> LinkedDatasets => _linkedDatasets;
 
     private Project(string title, string? description = null)

--- a/src/OStats.Domain/Common/AggregateRoot.cs
+++ b/src/OStats.Domain/Common/AggregateRoot.cs
@@ -2,6 +2,6 @@ namespace OStats.Domain.Common;
 
 public abstract class AggregateRoot : Entity
 {
-    private protected readonly List<IDomainEvent> _domainEvents = new List<IDomainEvent>();
+    private protected readonly List<IDomainEvent> _domainEvents = [];
     public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 }

--- a/src/OStats.Tests/IntegrationTests/JwtToken.cs
+++ b/src/OStats.Tests/IntegrationTests/JwtToken.cs
@@ -5,7 +5,7 @@ namespace OStats.Tests.IntegrationTests;
 
 public class TestJwtToken
 {
-    public List<Claim> Claims { get; } = new();
+    public List<Claim> Claims { get; } = [];
     public int ExpiresInMinutes { get; set; } = 30;
 
     public TestJwtToken WithRole(string roleName)

--- a/src/OStats.Tests/IntegrationTests/Queries/PeopleSearchQueryIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Queries/PeopleSearchQueryIntegrationTest.cs
@@ -8,8 +8,8 @@ namespace OStats.Tests.IntegrationTests.Queries;
 public class PeopleSearchQueryIntegrationTest : BaseIntegrationTest
 {
     // https://www.name-generator.org.uk/quick/
-    protected readonly List<string> GeneratedNames = new()
-    {
+    protected readonly List<string> GeneratedNames =
+    [
         "Tyrese Castillo",
         "Brodie Castillo",
         "Helen Moss",
@@ -20,7 +20,7 @@ public class PeopleSearchQueryIntegrationTest : BaseIntegrationTest
         "Orlando Frazier",
         "Zaara Mcconnell",
         "Kane Barnes"
-    };
+    ];
 
     public PeopleSearchQueryIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
     {


### PR DESCRIPTION
This pull request includes changes to initialize collections using the simplified inline array initialization syntax across multiple files. The most important changes include updates to aggregate root classes, domain common classes, and integration test classes.

### Aggregate Root Classes:
* [`src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs`](diffhunk://#diff-641f2d9442ea5cbc8388f2c59e2cf9df5226a8221fc8ee97e39e8cbaa6dadccfL13-R13): Changed the initialization of `_datasetUsersAccessesLevels` to use inline array initialization.
* [`src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs`](diffhunk://#diff-c86c1793d958b925522f1c1dce693962f6fadc51998b3bdbe61aad68f28afe18L10-R12): Changed the initialization of `_roles` and `_linkedDatasets` to use inline array initialization.

### Domain Common Classes:
* [`src/OStats.Domain/Common/AggregateRoot.cs`](diffhunk://#diff-ee69c9ccf353dca23f226837565c69fd21eb9d391283f743f3b6b09a5f35a1b3L5-R5): Changed the initialization of `_domainEvents` to use inline array initialization.

### Integration Test Classes:
* [`src/OStats.Tests/IntegrationTests/JwtToken.cs`](diffhunk://#diff-aa0ce05e244e41f0cc795af820328d995d627c9dfc992697fdf5204c9c4d0b24L8-R8): Changed the initialization of `Claims` to use inline array initialization.
* [`src/OStats.Tests/IntegrationTests/Queries/PeopleSearchQueryIntegrationTest.cs`](diffhunk://#diff-0d28194cafb4f89186d7fb026ac4c93a715dbd961bd0a5d92b908fa8d980ae98L11-R12): Changed the initialization of `GeneratedNames` to use inline array initialization. [[1]](diffhunk://#diff-0d28194cafb4f89186d7fb026ac4c93a715dbd961bd0a5d92b908fa8d980ae98L11-R12) [[2]](diffhunk://#diff-0d28194cafb4f89186d7fb026ac4c93a715dbd961bd0a5d92b908fa8d980ae98L23-R23)…els and tests