### PR TITLE
refactor: remove NSubstitute package from test project

### DIFF
--- a/src/OStats.Tests/OStats.Tests.csproj
+++ b/src/OStats.Tests/OStats.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request includes a small change to the `src/OStats.Tests/OStats.Tests.csproj` file. The change removes the `NSubstitute` package reference.

* Removed `NSubstitute` package reference from `src/OStats.Tests/OStats.Tests.csproj`.