### PR TITLE
fix: fix possible null values in rabbitmq env

### DIFF
--- a/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
@@ -69,8 +69,8 @@ public static class ServiceCollectionExtensions
                 var host = Environment.GetEnvironmentVariable("RABBITMQ_DEFAULT_HOST");
                 cfg.Host(host, "/", h =>
                 {
-                    h.Username(Environment.GetEnvironmentVariable("RABBITMQ_DEFAULT_USER"));
-                    h.Password(Environment.GetEnvironmentVariable("RABBITMQ_DEFAULT_PASS"));
+                    h.Username(Environment.GetEnvironmentVariable("RABBITMQ_DEFAULT_USER") ?? throw new ArgumentNullException("RABBITMQ_DEFAULT_USER"));
+                    h.Password(Environment.GetEnvironmentVariable("RABBITMQ_DEFAULT_PASS") ?? throw new ArgumentNullException("RABBITMQ_DEFAULT_PASS"));
                 });
             });
         });


### PR DESCRIPTION
This pull request includes a change to the `AddMessageBroker` method in the `ServiceCollectionExtensions` class. The change ensures that environment variables for RabbitMQ credentials are not null by throwing an `ArgumentNullException` if they are missing.

* [`src/OStats.API/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-f0ee9c91e3fdb735248d779d76771f28e0361383a0438da00ec0a767114a5a5cL72-R73): Modified the `AddMessageBroker` method to throw an `ArgumentNullException` if the `RABBITMQ_DEFAULT_USER` or `RABBITMQ_DEFAULT_PASS` environment variables are not set.