### PR TITLE
feat: add metadata events

### DIFF
--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdate.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdate.cs
@@ -1,0 +1,10 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.ProjectAggregate.Events;
+public sealed record DescriptionUpdate : IDomainEvent
+{
+    public required Guid ProjectId {get; init;}
+    public required Guid RequestorId {get; init;}
+    public required string OldDescription {get; init;}
+    public required string Description {get; init;}
+}

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdate.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdate.cs
@@ -1,0 +1,10 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.ProjectAggregate.Events;
+public sealed record TitleUpdate : IDomainEvent
+{
+    public required Guid ProjectId { get; init; }
+    public required Guid RequestorId { get; init; }
+    public required string OldTitle { get; init; }
+    public required string Title { get; init; }
+}

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -73,8 +73,7 @@ public sealed class Project : AggregateRoot
 
     public DomainOperationResult AddOrUpdateUserRole(Guid userId, AccessLevel accessLevel, Guid requestorId)
     {
-        var requestorRole = _roles.GetUserRole(requestorId)!;
-        if (IsAllowedTo(requestorRole, AccessLevel.Administrator) is var result && !result.Succeeded)
+        if (IsAllowedTo(_roles.GetUserRole(requestorId)!, AccessLevel.Administrator) is var result && !result.Succeeded)
         {
             return result;
         }
@@ -93,9 +92,8 @@ public sealed class Project : AggregateRoot
     }
 
     public DomainOperationResult RemoveUserRole(Guid userId, Guid requestorId)
-    {
-        var requestorRole = _roles.GetUserRole(requestorId)!;
-        if (IsAllowedTo(requestorRole, AccessLevel.Administrator) is var result && !result.Succeeded)
+    {;
+        if (IsAllowedTo(_roles.GetUserRole(requestorId)!, AccessLevel.Administrator) is var result && !result.Succeeded)
         {
             return result;
         }

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -92,7 +92,7 @@ public sealed class Project : AggregateRoot
     }
 
     public DomainOperationResult RemoveUserRole(Guid userId, Guid requestorId)
-    {;
+    {
         if (IsAllowedTo(_roles.GetUserRole(requestorId)!, AccessLevel.Administrator) is var result && !result.Succeeded)
         {
             return result;

--- a/src/OStats.Domain/Common/DomainOperationResult.cs
+++ b/src/OStats.Domain/Common/DomainOperationResult.cs
@@ -1,0 +1,16 @@
+namespace OStats.Domain.Common;
+
+public record DomainOperationResult(bool Succeeded, string? ErrorType = null, string? ErrorMessage = null)
+{
+    public static DomainOperationResult Success => new(true);
+
+    public static DomainOperationResult Failure(string? errorMessage) => new(false, "Failure", errorMessage ?? "An error occurred.");
+
+    public static DomainOperationResult InvalidUserRole() => new(false, "InvalidUserRole", "Invalid user role.");
+    public static DomainOperationResult InvalidUserRole(string errorMessage) => new(false, "InvalidUserRole", errorMessage);
+    
+    public static DomainOperationResult NoActionTaken(string? errorMessage) => new(false, "NoActionTaken", errorMessage ?? "No action taken.");
+
+    public static DomainOperationResult Unauthorized() => new(false, "Unauthorized", "Unauthorized.");
+    public static DomainOperationResult Unauthorized(string? errorMessage) => new(false, "Unauthorized", errorMessage ?? "Unauthorized.");
+}

--- a/src/OStats.Domain/Common/OperationResult.cs
+++ b/src/OStats.Domain/Common/OperationResult.cs
@@ -1,9 +1,0 @@
-namespace OStats.Domain.Common;
-
-public record DomainOperationResult(bool Succeeded, string? ErrorType = null, string? ErrorMessage = null)
-{
-    public static DomainOperationResult Success => new DomainOperationResult(true);
-    public static DomainOperationResult Failure(string errorMessage) => new DomainOperationResult(false, "Failure", errorMessage);
-    public static DomainOperationResult NoActionTaken(string errorMessage) => new DomainOperationResult(false, "NoActionTaken", errorMessage);
-    public static DomainOperationResult Unauthorized(string errorMessage) => new DomainOperationResult(false, "Unauthorized", errorMessage);
-}

--- a/src/OStats.Infrastructure/Context.cs
+++ b/src/OStats.Infrastructure/Context.cs
@@ -11,19 +11,19 @@ namespace OStats.Infrastructure;
 public sealed class Context : DbContext
 {
     // DatasetAggregate db sets
-    public DbSet<Dataset> Datasets { get; set; }
-    public DbSet<DatasetUserAccessLevel> DatasetsUsersAccessLevels { get; set; }
+    public required DbSet<Dataset> Datasets { get; set; }
+    public required DbSet<DatasetUserAccessLevel> DatasetsUsersAccessLevels { get; set; }
 
     // ProjectAggregate db sets
-    public DbSet<Project> Projects { get; set; }
-    public DbSet<Role> Roles { get; set; }
-    public DbSet<DatasetProjectLink> DatasetsProjectsLinks { get; set; }
+    public required DbSet<Project> Projects { get; set; }
+    public required DbSet<Role> Roles { get; set; }
+    public required DbSet<DatasetProjectLink> DatasetsProjectsLinks { get; set; }
 
     // UserAggregate db sets
-    public DbSet<User> Users { get; set; }
+    public required DbSet<User> Users { get; set; }
 
     // History db sets
-    public DbSet<AggregateHistoryEntry> AggregatesHistoryEntries { get; set; }
+    public required DbSet<AggregateHistoryEntry> AggregatesHistoryEntries { get; set; }
 
     public Context(DbContextOptions options) : base(options) 
     {

--- a/src/OStats.Tests/IntegrationTests/Commands/UpdateProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/UpdateProjectIntegrationTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OStats.API.Commands;
 using OStats.API.Dtos;
 using OStats.Domain.Aggregates.ProjectAggregate;
+using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
 
 namespace OStats.Tests.IntegrationTests.Commands;
 
@@ -50,7 +51,7 @@ public class UpdateProjectIntegrationTest : BaseIntegrationTest
         var previousLastUpdatedAtDatetime = project.LastUpdatedAt;
         var editedTitle = "Edited Title";
         var editedDescription = "Edited description";
-        project.Title = "Bypassed edition";
+        project.SetTitle("Bypassed edition", project.Roles.GetUserRole(user.Id)!);
         await context.SaveChangesAsync();
         var command = new UpdateProjectCommand(project.Id, user.AuthIdentity, editedTitle, previousLastUpdatedAtDatetime, editedDescription);
         var (result, baseProjectDto) = await serviceProvider.GetRequiredService<UpdateProjectCommandHandler>().Handle(command, default);

--- a/src/OStats.Tests/UnitTests/Domain/Aggregates/ProjectAggregates/ProjectTest.cs
+++ b/src/OStats.Tests/UnitTests/Domain/Aggregates/ProjectAggregates/ProjectTest.cs
@@ -1,4 +1,5 @@
 using OStats.Domain.Aggregates.ProjectAggregate;
+using OStats.Domain.Aggregates.ProjectAggregate.Events;
 
 namespace OStats.Tests.UnitTests.Domain.Aggregates.ProjectAggregate;
 
@@ -69,5 +70,59 @@ public class ProjectTest
         project.GetUserRole(randomGuid)
                .Should()
                .BeNull();
+    }
+
+    [Fact]
+    public void Should_Be_Able_To_Update_Project_Title()
+    {
+        var ownerId = Guid.NewGuid();
+        var project = new Project(ownerId, "Test Title", "Test Description");
+        var newTitle = "New Title";
+
+        project.SetTitle(newTitle, project.GetUserRole(ownerId)!);
+
+        project.Title.Should().Be(newTitle);
+        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is TitleUpdate);
+    }
+
+    [Fact]
+    public void Should_Fail_To_Update_Project_Title_If_Requestor_Is_Not_An_Editor()
+    {
+        var ownerId = Guid.NewGuid();
+        var project = new Project(ownerId, "Test Title", "Test Description");
+        var newTitle = "New Title";
+
+        var result = project.SetTitle(newTitle, new Role(ownerId, ownerId, AccessLevel.ReadOnly));
+
+        result.Succeeded.Should().BeFalse();
+        project.Title.Should().NotBe(newTitle);
+        project.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Should_Be_Able_To_Update_Project_Description()
+    {
+        var ownerId = Guid.NewGuid();
+        var project = new Project(ownerId, "Test Title", "Test Description");
+        var newDescription = "New Description";
+
+        project.SetDescription(newDescription, project.GetUserRole(ownerId)!);
+
+        project.Description.Should().Be(newDescription);
+        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is DescriptionUpdate);
+    }
+
+    [Fact]
+    public void Should_Fail_To_Update_Project_Description_If_Requestor_Is_Not_An_Editor()
+    {
+        var ownerId = Guid.NewGuid();
+        var project = new Project(ownerId, "Test Title", "Test Description");
+        var newDescription = "New Description";
+
+        var result = project.SetDescription(newDescription, new Role(ownerId, ownerId, AccessLevel.ReadOnly));
+
+        result.Succeeded.Should().BeFalse();
+        project.Description.Should().NotBe(newDescription);
+        project.DomainEvents.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of project updates and user roles in the OStats API. The changes focus on enhancing the domain logic for project updates, introducing new domain events, and ensuring stricter access control.

Enhancements to project update handling:

* [`src/OStats.API/Commands/UpdateProjectCommandHandler.cs`](diffhunk://#diff-5b72b34f7dc0fcc6979f096a4b00e3af71b757acee4959e1597e50054be7b4b0L36-R42): Modified the logic to check user roles and update project title and description using new methods.
* [`src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs`](diffhunk://#diff-c86c1793d958b925522f1c1dce693962f6fadc51998b3bdbe61aad68f28afe18R34-R79): Introduced `SetTitle` and `SetDescription` methods to handle title and description updates, including role validation.

Introduction of new domain events:

* [`src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdate.cs`](diffhunk://#diff-a96a7fbada18765c925c2828ab5fd139b20e2996b2785ee24d95a8d0dd150596R1-R10): Added a new domain event `DescriptionUpdate` to capture description changes.
* [`src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdate.cs`](diffhunk://#diff-687e15b344fe4f2d3996d0918f619ea13b7f283a9f223ae96f458064036271ceR1-R10): Added a new domain event `TitleUpdate` to capture title changes.

Improvements in access control:

* [`src/OStats.Domain/Common/DomainOperationResult.cs`](diffhunk://#diff-7c27ed53325cf8a1147ac39a14c21313086fbae508de33ffc4da7d2b5ba57e5cR1-R16): Added new static methods to handle different types of domain operation results, such as `InvalidUserRole` and `Unauthorized`.

These changes enhance the robustness and maintainability of the project update process by ensuring proper role validation and capturing changes through domain events.