### PR TITLE
feat: add soft delete

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -25,6 +25,9 @@ on:
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   codacy-security-scan:
     permissions:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.READ_PRIVATE_PACKAGES_TOKEN }}
       
       - name: Test with coverage report
         run: |

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Test with coverage report
         run: |
           bash ./scripts/get_test_coverage_report.sh

--- a/Readme.md
+++ b/Readme.md
@@ -23,11 +23,11 @@ source scripts/get_test_coverage_report.sh
 Generate migration
 
 ```text
-dotnet ef migrations add <MIGRATION_NAME> --project src/OStats.Infrastructure/
+dotnet ef migrations add AddSoftDelete --project src/OStats.Infrastructure/ --startup-project src/OStats.API/
 ```
 
 Generate idempotent script
 
 ```text
-dotnet ef migrations script --idempotent --output=./migration.sql --project src/OStats.Infrastructure/
+dotnet ef migrations script --idempotent --output=./migration.sql --project src/OStats.Infrastructure/ --startup-project src/OStats.API/
 ```

--- a/src/OStats.API/Apis/UsersApi.cs
+++ b/src/OStats.API/Apis/UsersApi.cs
@@ -18,8 +18,21 @@ public static class UsersApi
         app.MapGet("/{userId:Guid}", GetUserByIdAsync);
         app.MapGet("/{userId:Guid}/projects", GetUserProjectsAsync);
         app.MapGet("/{userId:Guid}/datasets", GetUserDatasetsHandler);
+        app.MapDelete("/{userId:Guid}", DeleteUserHandler);
 
         return app;
+    }
+
+    private static async Task<Results<Ok, BadRequest<string>>> DeleteUserHandler(
+        [FromRoute] Guid userId,
+        HttpContext context,
+        [FromServices] DeleteUserCommandHandler commandHandler,
+        CancellationToken cancellationToken)
+    {
+        var userAuthId = context.GetUserAuthId();
+        var command = new DeleteUserCommand { UserId = userId, UserAuthId = userAuthId };
+        var result = await commandHandler.Handle(command, cancellationToken);
+        return result.Succeeded ? TypedResults.Ok() : TypedResults.BadRequest(result.ErrorMessage);
     }
 
     private static async Task<Ok<List<BaseUserDto>>> PeopleSearchHandler(

--- a/src/OStats.API/Commands/CleanupDeletedDatasetResourcesCommand.cs
+++ b/src/OStats.API/Commands/CleanupDeletedDatasetResourcesCommand.cs
@@ -1,0 +1,5 @@
+namespace OStats.API.Commands;
+public sealed record CleanupDeletedDatasetResourcesCommand
+{
+    public required Guid DatasetId { get; init; }
+}

--- a/src/OStats.API/Commands/CleanupDeletedDatasetResourcesCommandHandler.cs
+++ b/src/OStats.API/Commands/CleanupDeletedDatasetResourcesCommandHandler.cs
@@ -1,0 +1,65 @@
+using DataServiceGrpc;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using OStats.API.Commands.Common;
+using OStats.Domain.Common;
+using OStats.Infrastructure;
+
+namespace OStats.API.Commands;
+public sealed class CleanupDeletedDatasetResourcesCommandHandler : CommandHandler<CleanupDeletedDatasetResourcesCommand, DomainOperationResult>
+{
+    private readonly DataService.DataServiceClient _dataServiceClient;
+    public CleanupDeletedDatasetResourcesCommandHandler(Context context, IPublishEndpoint publishEndpoint, DataService.DataServiceClient dataServiceClient) : base(context, publishEndpoint)
+    {
+        _dataServiceClient = dataServiceClient;
+    }
+
+    public override async Task<DomainOperationResult> Handle(CleanupDeletedDatasetResourcesCommand command, CancellationToken cancellationToken)
+    {
+        var databaseCleanup = CleanupDatabaseAsync(command.DatasetId, cancellationToken);
+        var storageCleanup = CleanupStorageAsync(command.DatasetId, cancellationToken);
+
+        await Task.WhenAll(databaseCleanup, storageCleanup);
+
+        if (databaseCleanup.Result.Succeeded && storageCleanup.Result.Succeeded)
+        {
+            return DomainOperationResult.Success;
+        }
+
+        return DomainOperationResult.Failure("Failed to cleanup dataset resources");
+    }
+
+    private async Task<DomainOperationResult> CleanupDatabaseAsync(Guid datasetId, CancellationToken cancellationToken)
+    {
+        var dataset = await _context.Datasets
+            .Include(dataset => dataset.DatasetUserAccessLevels)
+            .FirstOrDefaultAsync(dataset => dataset.Id == datasetId, cancellationToken: cancellationToken);
+
+        if (dataset is null)
+        {
+            return DomainOperationResult.NoActionTaken("Dataset is already deleted from database");
+        }
+
+        if (!dataset.IsDeleted)
+        {
+            return DomainOperationResult.Failure("Dataset is not deleted");
+        }
+
+        _context.Remove(dataset);
+        await SaveCommandHandlerChangesAsync(cancellationToken);
+        return DomainOperationResult.Success;
+    }
+
+    private async Task<DomainOperationResult> CleanupStorageAsync(Guid datasetId, CancellationToken cancellationToken)
+    {
+        var request = new DeleteDatasetRequest { DatasetId = datasetId.ToString() };
+        var response = await _dataServiceClient.DeleteDatasetAsync(request, cancellationToken: cancellationToken);
+
+        if (response.Success)
+        {
+            return DomainOperationResult.Success;
+        }
+
+        return DomainOperationResult.Failure("Failed to delete dataset from storage");
+    }
+}

--- a/src/OStats.API/Commands/CleanupDeletedProjectResourcesCommand.cs
+++ b/src/OStats.API/Commands/CleanupDeletedProjectResourcesCommand.cs
@@ -1,0 +1,5 @@
+namespace OStats.API.Commands;
+public sealed record CleanupDeletedProjectResourcesCommand
+{
+    public required Guid ProjectId { get; init; }
+}

--- a/src/OStats.API/Commands/CleanupDeletedProjectResourcesCommandHandler.cs
+++ b/src/OStats.API/Commands/CleanupDeletedProjectResourcesCommandHandler.cs
@@ -1,0 +1,33 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using OStats.API.Commands.Common;
+using OStats.Domain.Common;
+using OStats.Infrastructure;
+
+namespace OStats.API.Commands;
+public sealed class CleanupDeletedProjectResourcesCommandHandler : CommandHandler<CleanupDeletedProjectResourcesCommand, DomainOperationResult>
+{
+    public CleanupDeletedProjectResourcesCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
+    {
+    }
+
+    public override async Task<DomainOperationResult> Handle(CleanupDeletedProjectResourcesCommand command, CancellationToken cancellationToken)
+    {
+        var project = await _context.Projects.IgnoreQueryFilters().SingleOrDefaultAsync(p => p.Id == command.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            return DomainOperationResult.NoActionTaken("Project is already deleted from database");
+        }
+
+        if (!project.IsDeleted)
+        {
+            return DomainOperationResult.Failure("Project is not deleted");
+        }
+
+        _context.Remove(project);
+
+        await SaveCommandHandlerChangesAsync(cancellationToken);
+        return DomainOperationResult.Success;
+    }
+}

--- a/src/OStats.API/Commands/CleanupDeletedUserResourcesCommand.cs
+++ b/src/OStats.API/Commands/CleanupDeletedUserResourcesCommand.cs
@@ -1,0 +1,5 @@
+namespace OStats.API.Commands;
+public sealed record CleanupDeletedUserResourcesCommand
+{
+    public required Guid UserId { get; init; }
+}

--- a/src/OStats.API/Commands/CleanupDeletedUserResourcesCommandHandler.cs
+++ b/src/OStats.API/Commands/CleanupDeletedUserResourcesCommandHandler.cs
@@ -1,0 +1,69 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using OStats.API.Commands.Common;
+using OStats.Domain.Aggregates.DatasetAggregate;
+using OStats.Domain.Aggregates.ProjectAggregate;
+using OStats.Domain.Common;
+using OStats.Infrastructure;
+
+namespace OStats.API.Commands;
+public sealed class CleanupDeletedUserResourcesCommandHandler : CommandHandler<CleanupDeletedUserResourcesCommand, DomainOperationResult>
+{
+    public CleanupDeletedUserResourcesCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
+    {
+    }
+
+    public override async Task<DomainOperationResult> Handle(CleanupDeletedUserResourcesCommand command, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users.IgnoreQueryFilters().SingleOrDefaultAsync(_user => _user.Id == command.UserId, cancellationToken);
+
+        if (user is null)
+        {
+            return DomainOperationResult.NoActionTaken("User is already deleted from database");
+        }
+
+        if (!user.IsDeleted)
+        {
+            return DomainOperationResult.Failure("User is not deleted");
+        }
+
+        List<Dataset> datasetsSingleOwnedByUser = await GetDatasetsOwnedOnlyByDeletedUserAsync(user.Id, cancellationToken);
+        foreach (var dataset in datasetsSingleOwnedByUser)
+        {
+            dataset.Delete(user.Id);
+        }
+
+        List<Project> projectsSingleOwnedByUser = await GetProjectsOwnedOnlyByDeletedUserAsync(user.Id, cancellationToken);
+        foreach (var project in projectsSingleOwnedByUser)
+        {
+            project.Delete(user.Id);
+        }
+
+        _context.Remove(user);
+
+        await SaveCommandHandlerChangesAsync(cancellationToken);
+        return DomainOperationResult.Success;
+    }
+
+    private Task<List<Dataset>> GetDatasetsOwnedOnlyByDeletedUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        return _context.Datasets
+            .Where(_ => _context.DatasetsUsersAccessLevels.Any(accessLevel => accessLevel.UserId == userId && accessLevel.AccessLevel == DatasetAccessLevel.Owner))
+            .Join(_context.DatasetsUsersAccessLevels, dataset => dataset.Id, accessLevel => accessLevel.DatasetId, (dataset, accessLevel) => dataset)
+            .GroupBy(dataset => dataset.Id)
+            .Where(group => group.Count() == 1)
+            .SelectMany(group => group.ToList())
+            .ToListAsync(cancellationToken);
+    }
+
+    private Task<List<Project>> GetProjectsOwnedOnlyByDeletedUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        return _context.Projects
+            .Where(_ => _context.Roles.Any(role => role.UserId == userId && role.AccessLevel == AccessLevel.Owner))
+            .Join(_context.Roles, project => project.Id, role => role.ProjectId, (project, role) => project)
+            .GroupBy(project => project.Id)
+            .Where(group => group.Count() == 1)
+            .SelectMany(group => group.ToList())
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/OStats.API/Commands/CleanupDeletedUserResourcesCommandHandler.cs
+++ b/src/OStats.API/Commands/CleanupDeletedUserResourcesCommandHandler.cs
@@ -49,7 +49,7 @@ public sealed class CleanupDeletedUserResourcesCommandHandler : CommandHandler<C
     {
         return _context.Datasets
             .Where(_ => _context.DatasetsUsersAccessLevels.Any(accessLevel => accessLevel.UserId == userId && accessLevel.AccessLevel == DatasetAccessLevel.Owner))
-            .Join(_context.DatasetsUsersAccessLevels, dataset => dataset.Id, accessLevel => accessLevel.DatasetId, (dataset, accessLevel) => dataset)
+            .Join(_context.DatasetsUsersAccessLevels, dataset => dataset.Id, accessLevel => accessLevel.DatasetId, (dataset, _) => dataset)
             .GroupBy(dataset => dataset.Id)
             .Where(group => group.Count() == 1)
             .SelectMany(group => group.ToList())
@@ -60,7 +60,7 @@ public sealed class CleanupDeletedUserResourcesCommandHandler : CommandHandler<C
     {
         return _context.Projects
             .Where(_ => _context.Roles.Any(role => role.UserId == userId && role.AccessLevel == AccessLevel.Owner))
-            .Join(_context.Roles, project => project.Id, role => role.ProjectId, (project, role) => project)
+            .Join(_context.Roles, project => project.Id, role => role.ProjectId, (project, _) => project)
             .GroupBy(project => project.Id)
             .Where(group => group.Count() == 1)
             .SelectMany(group => group.ToList())

--- a/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
@@ -26,12 +26,7 @@ public sealed class DeleteDatasetCommandHandler : CommandHandler<DeleteDatasetCo
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        if (dataset.GetUserAccessLevel(user.Id) < DatasetAccessLevel.Owner)
-        {
-            return DomainOperationResult.Failure("User does not have permission to delete this dataset.");
-        }
-
-        _context.Remove(dataset);
+        dataset.Delete(user.Id);
         await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return DomainOperationResult.Success;

--- a/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
@@ -1,7 +1,5 @@
 using MassTransit;
 using OStats.API.Commands.Common;
-using OStats.Domain.Aggregates.ProjectAggregate;
-using OStats.Domain.Aggregates.ProjectAggregate.Extensions;
 using OStats.Domain.Common;
 using OStats.Infrastructure;
 
@@ -27,13 +25,12 @@ public sealed class DeleteProjectCommandHandler : CommandHandler<DeleteProjectCo
             return DomainOperationResult.Failure("Project not found.");
         }
 
-        var isUserOwner = project.Roles.IsUser(user.Id, AccessLevel.Owner);
-        if (!isUserOwner)
+        var result = project.Delete(user.Id);
+        if (!result.Succeeded)
         {
-            return DomainOperationResult.Failure("User does not have permission to delete this project.");
+            return result;
         }
-
-        _context.Remove(project);
+        
         await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return DomainOperationResult.Success;

--- a/src/OStats.API/Commands/DeleteUserCommand.cs
+++ b/src/OStats.API/Commands/DeleteUserCommand.cs
@@ -1,0 +1,7 @@
+namespace OStats.API.Commands;
+
+public sealed record DeleteUserCommand
+{
+    public required string UserAuthId { get; init; }
+    public required Guid UserId { get; init; }
+}

--- a/src/OStats.API/Commands/DeleteUserCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteUserCommandHandler.cs
@@ -1,0 +1,37 @@
+using MassTransit;
+using OStats.API.Commands.Common;
+using OStats.Domain.Common;
+using OStats.Infrastructure;
+
+namespace OStats.API.Commands;
+
+public sealed class DeleteUserCommandHandler : CommandHandler<DeleteUserCommand, DomainOperationResult>
+{
+    public DeleteUserCommandHandler(Context context, IPublishEndpoint publishEndpoint) : base(context, publishEndpoint)
+    {
+    }
+
+    public override async Task<DomainOperationResult> Handle(DeleteUserCommand command, CancellationToken cancellationToken)
+    {
+        var requestor = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
+        if (requestor is null)
+        {
+            return DomainOperationResult.Failure("Requestor not found.");
+        }
+
+        var toBeDeletedUser = await _context.Users.FindAsync(command.UserId, cancellationToken);
+        if (toBeDeletedUser is null)
+        {
+            return DomainOperationResult.Failure("User not found.");
+        }
+
+        var result = toBeDeletedUser.Delete(requestor.Id);
+        if (!result.Succeeded)
+        {
+            return result;
+        }
+        
+        await SaveCommandHandlerChangesAsync(cancellationToken);
+        return DomainOperationResult.Success;
+    }
+}

--- a/src/OStats.API/Consumers/DeletedDatasetDomainEventConsumer.cs
+++ b/src/OStats.API/Consumers/DeletedDatasetDomainEventConsumer.cs
@@ -1,0 +1,25 @@
+using MassTransit;
+using OStats.API.Commands;
+using OStats.Domain.Aggregates.DatasetAggregate.Events;
+
+namespace OStats.API.Consumers;
+
+public sealed class DeletedDatasetDomainEventConsumer : IConsumer<DeletedDatasetDomainEvent>
+{
+    private readonly CleanupDeletedDatasetResourcesCommandHandler _handler;
+    public DeletedDatasetDomainEventConsumer(CleanupDeletedDatasetResourcesCommandHandler handler)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public async Task Consume(ConsumeContext<DeletedDatasetDomainEvent> context)
+    {
+        var command = new CleanupDeletedDatasetResourcesCommand { DatasetId = context.Message.DatasetId };
+        var result = await _handler.Handle(command, context.CancellationToken);
+        
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(result.ErrorMessage);
+        }
+    }
+}

--- a/src/OStats.API/Consumers/DeletedProjectDomainEventConsumer.cs
+++ b/src/OStats.API/Consumers/DeletedProjectDomainEventConsumer.cs
@@ -1,0 +1,25 @@
+using MassTransit;
+using OStats.API.Commands;
+using OStats.Domain.Aggregates.ProjectAggregate.Events;
+
+namespace OStats.API.Consumers;
+
+public sealed class DeletedProjectDomainEventConsumer : IConsumer<DeletedProjectDomainEvent>
+{
+    private readonly CleanupDeletedProjectResourcesCommandHandler _handler;
+    public DeletedProjectDomainEventConsumer(CleanupDeletedProjectResourcesCommandHandler handler)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public async Task Consume(ConsumeContext<DeletedProjectDomainEvent> context)
+    {
+        var command = new CleanupDeletedProjectResourcesCommand { ProjectId = context.Message.ProjectId };
+        var result = await _handler.Handle(command, context.CancellationToken);
+        
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(result.ErrorMessage);
+        }
+    }
+}

--- a/src/OStats.API/Consumers/DeletedUserDomainEventConsumer.cs
+++ b/src/OStats.API/Consumers/DeletedUserDomainEventConsumer.cs
@@ -1,0 +1,25 @@
+using MassTransit;
+using OStats.API.Commands;
+using OStats.Domain.Aggregates.UserAggregate.Events;
+
+namespace OStats.API.Consumers;
+
+public sealed class DeletedUserDomainEventConsumer : IConsumer<DeletedUserDomainEvent>
+{
+    private readonly CleanupDeletedUserResourcesCommandHandler _handler;
+    public DeletedUserDomainEventConsumer(CleanupDeletedUserResourcesCommandHandler handler)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public async Task Consume(ConsumeContext<DeletedUserDomainEvent> context)
+    {
+        var command = new CleanupDeletedUserResourcesCommand { UserId = context.Message.UserId };
+        var result = await _handler.Handle(command, context.CancellationToken);
+        
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(result.ErrorMessage);
+        }
+    }
+}

--- a/src/OStats.API/Protos/dataservice.proto
+++ b/src/OStats.API/Protos/dataservice.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/struct.proto";
-
 package dataservice;
 
 option csharp_namespace = "DataServiceGrpc";
@@ -11,6 +9,7 @@ service DataService {
     // Ingest raw data from raw-datasets-uploads bucket and transforms them to parquet in datasets bucket
     rpc IngestData(IngestDataRequest) returns (IngestDataResponse) {}
     rpc GetData(GetDataRequest) returns (stream DataResponse) {}
+    rpc DeleteDataset(DeleteDatasetRequest) returns (DeleteDatasetResponse) {}
 }
 
 message IngestDataRequest {
@@ -30,4 +29,12 @@ message GetDataRequest {
 
 message DataResponse {
     string body = 1;
+}
+
+message DeleteDatasetRequest {
+    string datasetId = 1;
+}
+
+message DeleteDatasetResponse {
+    bool success = 1;
 }

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Dataset.cs
@@ -97,4 +97,16 @@ public sealed class Dataset : AggregateRoot
         _domainEvents.Add(new UpdatedDatasetVisibilityDomainEvent(Id, IsPublic, requestorId));
         return DomainOperationResult.Success;
     }
+
+    public DomainOperationResult Delete(Guid requestorId)
+    {
+        if (GetUserAccessLevel(requestorId) < DatasetAccessLevel.Owner)
+        {
+            return DomainOperationResult.Failure("Requestor does not have permission to delete dataset.");
+        }
+
+        _domainEvents.Add(new DeletedDatasetDomainEvent { DatasetId = Id, RequestorId = requestorId });
+        IsDeleted = true;
+        return DomainOperationResult.Success;
+    }
 }

--- a/src/OStats.Domain/Aggregates/DatasetAggregate/Events/DeletedDatasetDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/DatasetAggregate/Events/DeletedDatasetDomainEvent.cs
@@ -1,0 +1,9 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.DatasetAggregate.Events;
+
+public sealed record DeletedDatasetDomainEvent : IDomainEvent
+{
+    public required Guid DatasetId { get; init; }
+    public required Guid RequestorId { get; init; }
+}

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DeletedProjectDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DeletedProjectDomainEvent.cs
@@ -1,0 +1,9 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.ProjectAggregate.Events;
+
+public sealed record DeletedProjectDomainEvent : IDomainEvent
+{
+    public required Guid ProjectId { get; init; }
+    public required Guid RequestorId { get; init; }
+}

--- a/src/OStats.Domain/Aggregates/UserAggregate/Events/DeletedUserDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/UserAggregate/Events/DeletedUserDomainEvent.cs
@@ -1,0 +1,9 @@
+using OStats.Domain.Common;
+
+namespace OStats.Domain.Aggregates.UserAggregate.Events;
+
+public sealed record DeletedUserDomainEvent : IDomainEvent
+{
+    public required Guid UserId { get; init; }
+    public required Guid RequestorId { get; init; }
+}

--- a/src/OStats.Domain/Aggregates/UserAggregate/User.cs
+++ b/src/OStats.Domain/Aggregates/UserAggregate/User.cs
@@ -1,7 +1,7 @@
+using OStats.Domain.Aggregates.UserAggregate.Events;
 using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.UserAggregate;
-
 
 public sealed class User : AggregateRoot
 {
@@ -13,5 +13,22 @@ public sealed class User : AggregateRoot
         Name = name;
         Email = email;
         AuthIdentity = authIdentity;
+    }
+
+    public DomainOperationResult Delete(Guid requestorId)
+    {
+        if (IsDeleted)
+        {
+            return DomainOperationResult.NoActionTaken("User is already deleted");
+        }
+
+        if (requestorId != Id)
+        {
+            return DomainOperationResult.Unauthorized("Only the user can delete their account");
+        }
+
+        _domainEvents.Add(new DeletedUserDomainEvent { UserId = Id, RequestorId = requestorId });
+        IsDeleted = true;
+        return DomainOperationResult.Success;
     }
 }

--- a/src/OStats.Domain/Common/Entity.cs
+++ b/src/OStats.Domain/Common/Entity.cs
@@ -21,5 +21,5 @@ public abstract class Entity
 
     public DateTime CreatedAt { get; internal set; }
     public DateTime LastUpdatedAt { get; internal set; }
-    public bool IsDeleted { get; internal set; } = false;
+    public bool IsDeleted { get; internal set; }
 }

--- a/src/OStats.Domain/Common/Entity.cs
+++ b/src/OStats.Domain/Common/Entity.cs
@@ -1,3 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OStats.Infrastructure")]
+
 namespace OStats.Domain.Common;
 
 public abstract class Entity
@@ -15,6 +19,7 @@ public abstract class Entity
         }
     }
 
-    public DateTime CreatedAt { get; set; }
-    public DateTime LastUpdatedAt { get; set; }
+    public DateTime CreatedAt { get; internal set; }
+    public DateTime LastUpdatedAt { get; internal set; }
+    public bool IsDeleted { get; internal set; } = false;
 }

--- a/src/OStats.Infrastructure/EntitiesConfiguration/EntityConfiguration.cs
+++ b/src/OStats.Infrastructure/EntitiesConfiguration/EntityConfiguration.cs
@@ -9,5 +9,11 @@ internal abstract class EntityConfiguration<T> : IEntityTypeConfiguration<T> whe
     public virtual void Configure(EntityTypeBuilder<T> builder)
     {
         builder.HasKey(entity => entity.Id);
+        builder.Property(entity => entity.CreatedAt).IsRequired();
+        builder.Property(entity => entity.LastUpdatedAt).IsRequired();
+        
+        builder.Property(entity => entity.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.HasIndex(entity => entity.IsDeleted).HasFilter("\"IsDeleted\" = false");
+        builder.HasQueryFilter(entity => !entity.IsDeleted);
     }
 }

--- a/src/OStats.Infrastructure/Migrations/20250101142718_AddSoftDelete.Designer.cs
+++ b/src/OStats.Infrastructure/Migrations/20250101142718_AddSoftDelete.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OStats.Infrastructure;
@@ -11,9 +12,11 @@ using OStats.Infrastructure;
 namespace OStats.Infrastructure.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20250101142718_AddSoftDelete")]
+    partial class AddSoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OStats.Infrastructure/Migrations/20250101142718_AddSoftDelete.cs
+++ b/src/OStats.Infrastructure/Migrations/20250101142718_AddSoftDelete.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OStats.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSoftDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Roles",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Projects",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Projects",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "DatasetsUsersAccessLevels",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "DatasetsProjectsLinks",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Datasets",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_IsDeleted",
+                table: "Users",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_IsDeleted",
+                table: "Roles",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_IsDeleted",
+                table: "Projects",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DatasetsUsersAccessLevels_IsDeleted",
+                table: "DatasetsUsersAccessLevels",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DatasetsProjectsLinks_IsDeleted",
+                table: "DatasetsProjectsLinks",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_IsDeleted",
+                table: "Datasets",
+                column: "IsDeleted",
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_IsDeleted",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Roles_IsDeleted",
+                table: "Roles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_IsDeleted",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DatasetsUsersAccessLevels_IsDeleted",
+                table: "DatasetsUsersAccessLevels");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DatasetsProjectsLinks_IsDeleted",
+                table: "DatasetsProjectsLinks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Datasets_IsDeleted",
+                table: "Datasets");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Roles");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "DatasetsUsersAccessLevels");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "DatasetsProjectsLinks");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Datasets");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Projects",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048);
+        }
+    }
+}

--- a/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
@@ -25,6 +25,7 @@ public abstract class BaseIntegrationTest : IClassFixture<IntegrationTestWebAppF
         client = factory.CreateClient();
 
         SetDatabaseInitialState();
+        queueHarness.Start();
     }
 
     private void SetDatabaseInitialState()

--- a/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedDatasetResourcesIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedDatasetResourcesIntegrationTest.cs
@@ -1,0 +1,40 @@
+using FluentAssertions.Execution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OStats.API.Commands;
+
+namespace OStats.Tests.IntegrationTests.Commands;
+
+public class CleanupDeletedDatasetResourcesIntegrationTest : BaseIntegrationTest
+{
+    public CleanupDeletedDatasetResourcesIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_Dataset_Is_Not_Deleted()
+    {
+        var dataset = await context.Datasets.FirstAsync();
+        var command = new CleanupDeletedDatasetResourcesCommand { DatasetId = dataset.Id };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedDatasetResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_Dataset_Is_Not_Found()
+    {
+        var command = new CleanupDeletedDatasetResourcesCommand { DatasetId = Guid.NewGuid() };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedDatasetResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedProjectResourcesIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedProjectResourcesIntegrationTest.cs
@@ -1,0 +1,40 @@
+using FluentAssertions.Execution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OStats.API.Commands;
+
+namespace OStats.Tests.IntegrationTests.Commands;
+
+public class CleanupDeletedProjectResourcesIntegrationTest : BaseIntegrationTest
+{
+    public CleanupDeletedProjectResourcesIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_Project_Is_Not_Deleted()
+    {
+        var project = await context.Projects.FirstAsync();
+        var command = new CleanupDeletedProjectResourcesCommand { ProjectId = project.Id };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedProjectResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_Project_Is_Not_Found()
+    {
+        var command = new CleanupDeletedProjectResourcesCommand { ProjectId = Guid.NewGuid() };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedProjectResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedUserResourcesIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/CleanupDeletedUserResourcesIntegrationTest.cs
@@ -1,0 +1,40 @@
+using FluentAssertions.Execution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OStats.API.Commands;
+
+namespace OStats.Tests.IntegrationTests.Commands;
+
+public class CleanupDeletedUserResourcesIntegrationTest : BaseIntegrationTest
+{
+    public CleanupDeletedUserResourcesIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_User_Is_Not_Deleted()
+    {
+        var user = await context.Users.FirstAsync();
+        var command = new CleanupDeletedUserResourcesCommand { UserId = user.Id };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedUserResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Fail_If_User_Is_Not_Found()
+    {
+        var command = new CleanupDeletedUserResourcesCommand { UserId = Guid.NewGuid() };
+        var result = await serviceProvider.GetRequiredService<CleanupDeletedUserResourcesCommandHandler>().Handle(command, default);
+
+        using (new AssertionScope())
+        {
+            result.Succeeded.Should().BeFalse();
+            result.ErrorMessage.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
@@ -30,6 +30,8 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
         {
             result.Succeeded.Should().BeFalse();
             result.ErrorMessage.Should().NotBeEmpty();
+            var isDeleted = !await context.Projects.AnyAsync(p => p.Id == project.Id);
+            isDeleted.Should().BeFalse();
         }
     }
 
@@ -38,8 +40,8 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
     {
         var existingUser = await context.Users.FirstAsync();
         var project = new Project(existingUser.Id, "To Be Deleted", "No Description");
-        context.Projects.Add(project);
-        context.SaveChanges();
+        await context.Projects.AddAsync(project);
+        await context.SaveChangesAsync();
 
         var command = new DeleteProjectCommand(existingUser.AuthIdentity, project.Id);
         var result = await serviceProvider.GetRequiredService<DeleteProjectCommandHandler>().Handle(command, default);
@@ -50,7 +52,6 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
             result.ErrorMessage.Should().BeNullOrEmpty();
             context.Users.Any(u => u.Id == existingUser.Id).Should().BeTrue();
             context.Projects.Any(p => p.Id == project.Id).Should().BeFalse();
-            context.Roles.Any(r => r.ProjectId == project.Id).Should().BeFalse();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several significant changes to the OStats API, primarily focusing on adding delete functionality for users, datasets, and projects, as well as implementing cleanup commands and handlers for deleted resources. Additionally, it includes updates to the project structure and documentation.

### Key Changes:

#### API Enhancements:
* Added `DeleteUserHandler` to the `UsersApi` to handle user deletion requests.
* Introduced `DeleteDataset`, `DeleteProject`, and `DeleteUser` commands and their respective handlers to manage the deletion process. [[1]](diffhunk://#diff-945348f3171d0888e579ac115806e499f64e566788e7cf0d91502794522086d4R1-R7) [[2]](diffhunk://#diff-4fa698aae07f554c7d56ddd1a47b8bf46c6f398230aa433c8c109cadb15fabd5R1-R37) [[3]](diffhunk://#diff-a41afc3b877f5360ca9e2d7a95245482d4fad65b985ce033b4281870c3880a10R1-R5) [[4]](diffhunk://#diff-495bd7c70fc634a2fb9d7258bca394ddd17e7f567c8e60c56cffb7f0192bbab7R1-R65) [[5]](diffhunk://#diff-d7c725c5f8c01263c89507d41c4692c6cfd657d9cb5a4ba08af700b3df760696R1-R5) [[6]](diffhunk://#diff-63c5a77833da5504d794601ae601dd15154b9ff1b4377a3c168f0b56af1b545fR1-R33) [[7]](diffhunk://#diff-026b7fa27b8adef22e6b4aefbc3d653da1959ceb673fceda1ea091fcf952c5c1R1-R5) [[8]](diffhunk://#diff-c623c16aef735b60a607a91aafec949c94f1def5b06a68196f79be1a2e3fb446R1-R69)

#### Cleanup Commands:
* Created `CleanupDeletedDatasetResourcesCommand`, `CleanupDeletedProjectResourcesCommand`, and `CleanupDeletedUserResourcesCommand` to handle the cleanup of resources associated with deleted entities. [[1]](diffhunk://#diff-a41afc3b877f5360ca9e2d7a95245482d4fad65b985ce033b4281870c3880a10R1-R5) [[2]](diffhunk://#diff-495bd7c70fc634a2fb9d7258bca394ddd17e7f567c8e60c56cffb7f0192bbab7R1-R65) [[3]](diffhunk://#diff-d7c725c5f8c01263c89507d41c4692c6cfd657d9cb5a4ba08af700b3df760696R1-R5) [[4]](diffhunk://#diff-63c5a77833da5504d794601ae601dd15154b9ff1b4377a3c168f0b56af1b545fR1-R33) [[5]](diffhunk://#diff-026b7fa27b8adef22e6b4aefbc3d653da1959ceb673fceda1ea091fcf952c5c1R1-R5) [[6]](diffhunk://#diff-c623c16aef735b60a607a91aafec949c94f1def5b06a68196f79be1a2e3fb446R1-R69)

#### Domain Events:
* Added domain events for dataset, project, and user deletions to trigger cleanup operations. [[1]](diffhunk://#diff-b9badc14334334d48c762857493cdb5bd15e1f1b86b7c838efaf83b1c233ea6eR1-R9) [[2]](diffhunk://#diff-49d6710ebbdbfe4131fb5caa3e7a72ef5ad36ead42c461d668d0f659dc54de3bR1-R9) [[3]](diffhunk://#diff-641f2d9442ea5cbc8388f2c59e2cf9df5226a8221fc8ee97e39e8cbaa6dadccfR100-R111) [[4]](diffhunk://#diff-c86c1793d958b925522f1c1dce693962f6fadc51998b3bdbe61aad68f28afe18R107-R108)

#### Consumers:
* Implemented consumers for the new domain events to execute the cleanup commands when a dataset, project, or user is deleted. [[1]](diffhunk://#diff-5977bff0d662e8c4022a2686558cd887f91006407ce531a06f6abe46f4e7c4dbR1-R25) [[2]](diffhunk://#diff-2f1c6149d13cf4937e9c20263e77284654c5d5066ed7be717effcbfa64af9d8aR1-R25) [[3]](diffhunk://#diff-f56d7e0a82d627fe413e126c7f291acd9d2c1248c9102d700215110a60baa9cdR1-R25)

#### Documentation:
* Updated the `Readme.md` to reflect changes in the migration commands, including the addition of the `--startup-project` parameter.

These changes enhance the functionality of the OStats API by adding comprehensive delete and cleanup capabilities, ensuring that resources are properly managed and cleaned up when entities are deleted.