### PR TITLE
refactor: fix project events naming

### DIFF
--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdateDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdateDomainEvent.cs
@@ -1,7 +1,7 @@
 using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate.Events;
-public sealed record DescriptionUpdate : IDomainEvent
+public sealed record DescriptionUpdateDomainEvent : IDomainEvent
 {
     public required Guid ProjectId {get; init;}
     public required Guid RequestorId {get; init;}

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdateDomainEvent.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdateDomainEvent.cs
@@ -1,7 +1,7 @@
 using OStats.Domain.Common;
 
 namespace OStats.Domain.Aggregates.ProjectAggregate.Events;
-public sealed record TitleUpdate : IDomainEvent
+public sealed record TitleUpdateDomainEvent : IDomainEvent
 {
     public required Guid ProjectId { get; init; }
     public required Guid RequestorId { get; init; }

--- a/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/src/OStats.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -54,7 +54,7 @@ public sealed class Project : AggregateRoot
             return result;
         }
 
-        _domainEvents.Add(new TitleUpdate { ProjectId = Id, RequestorId = requestorRole.UserId, OldTitle = Title, Title = title });
+        _domainEvents.Add(new TitleUpdateDomainEvent { ProjectId = Id, RequestorId = requestorRole.UserId, OldTitle = Title, Title = title });
         Title = title;
         return result;
     }
@@ -66,7 +66,7 @@ public sealed class Project : AggregateRoot
             return result;
         }
 
-        _domainEvents.Add(new DescriptionUpdate { ProjectId = Id, RequestorId = requestorRole.UserId, OldDescription = Description, Description = description });
+        _domainEvents.Add(new DescriptionUpdateDomainEvent { ProjectId = Id, RequestorId = requestorRole.UserId, OldDescription = Description, Description = description });
         Description = description;
         return result;
     }

--- a/src/OStats.Tests/UnitTests/Domain/Aggregates/ProjectAggregates/ProjectTest.cs
+++ b/src/OStats.Tests/UnitTests/Domain/Aggregates/ProjectAggregates/ProjectTest.cs
@@ -82,7 +82,7 @@ public class ProjectTest
         project.SetTitle(newTitle, project.GetUserRole(ownerId)!);
 
         project.Title.Should().Be(newTitle);
-        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is TitleUpdate);
+        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is TitleUpdateDomainEvent);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class ProjectTest
         project.SetDescription(newDescription, project.GetUserRole(ownerId)!);
 
         project.Description.Should().Be(newDescription);
-        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is DescriptionUpdate);
+        project.DomainEvents.Should().ContainSingle(domainEvent => domainEvent is DescriptionUpdateDomainEvent);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request includes several changes to the `OStats.Domain` and `OStats.Tests` projects, primarily focusing on renaming domain event classes for better clarity and consistency. The most important changes include renaming event classes and updating references to these classes throughout the codebase.

Renaming domain event classes:

* `src/OStats.Domain/Aggregates/ProjectAggregate/Events/DescriptionUpdate.cs` was renamed to `DescriptionUpdateDomainEvent.cs`, and the class name was updated accordingly.
* `src/OStats.Domain/Aggregates/ProjectAggregate/Events/TitleUpdate.cs` was renamed to `TitleUpdateDomainEvent.cs`, and the class name was updated accordingly.

Updating references to renamed event classes:

* Updated references to `TitleUpdate` to `TitleUpdateDomainEvent` in `Project.cs`.
* Updated references to `DescriptionUpdate` to `DescriptionUpdateDomainEvent` in `Project.cs`.
* Updated unit tests to reflect the renaming of `TitleUpdate` to `TitleUpdateDomainEvent` in `ProjectTest.cs`.
* Updated unit tests to reflect the renaming of `DescriptionUpdate` to `DescriptionUpdateDomainEvent` in `ProjectTest.cs`.