### PR TITLE
feat: add UserContext and Middleware to validate user, adapt commands…

### DIFF
--- a/src/OStats.API/Commands/AddUserToDatasetCommand.cs
+++ b/src/OStats.API/Commands/AddUserToDatasetCommand.cs
@@ -4,14 +4,14 @@ namespace OStats.API.Commands;
 
 public sealed record AddUserToDatasetCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public Guid DatasetId { get; set; }
     public Guid UserId { get; set; }
     public DatasetAccessLevel AccessLevel { get; set; }
 
-    public AddUserToDatasetCommand(string userAuthId, Guid datasetId, Guid userId, DatasetAccessLevel accessLevel)
+    public AddUserToDatasetCommand(Guid requestorUserId, Guid datasetId, Guid userId, DatasetAccessLevel accessLevel)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         UserId = userId;
         DatasetId = datasetId;
         AccessLevel = accessLevel;

--- a/src/OStats.API/Commands/AddUserToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/AddUserToDatasetCommandHandler.cs
@@ -19,19 +19,13 @@ public sealed class AddUserToDatasetCommandHandler : CommandHandler<AddUserToDat
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        var requestor = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found.");
-        }
-
         var user = await _context.Users.FindAsync(command.UserId, cancellationToken);
         if (user is null)
         {
             return DomainOperationResult.Failure("User not found.");
         }
 
-        var result = dataset.GrantUserAccess(command.UserId, command.AccessLevel, requestor.Id);
+        var result = dataset.GrantUserAccess(command.UserId, command.AccessLevel, command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/AddUserToProjectCommand.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommand.cs
@@ -4,14 +4,14 @@ namespace OStats.API.Commands;
 
 public sealed record AddUserToProjectCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public Guid ProjectId { get; set; }
     public Guid UserId { get; set; }
     public AccessLevel AccessLevel { get; set; }
 
-    public AddUserToProjectCommand(string userAuthId, Guid projectId, Guid userId, AccessLevel accessLevel)
+    public AddUserToProjectCommand(Guid requestorUserId, Guid projectId, Guid userId, AccessLevel accessLevel)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         UserId = userId;
         ProjectId = projectId;
         AccessLevel = accessLevel;

--- a/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/AddUserToProjectCommandHandler.cs
@@ -11,21 +11,15 @@ public sealed class AddUserToProjectCommandHandler : CommandHandler<AddUserToPro
     {
     }
 
-    public override async Task<DomainOperationResult> Handle(AddUserToProjectCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(AddUserToProjectCommand command, CancellationToken cancellationToken)
     {
-        var project = await _context.Projects.FindAsync(request.ProjectId, cancellationToken);
+        var project = await _context.Projects.FindAsync(command.ProjectId, cancellationToken);
         if (project is null)
         {
             return DomainOperationResult.Failure("Project not found");
         }
 
-        var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found");
-        }
-
-        var result = project.AddOrUpdateUserRole(request.UserId, request.AccessLevel, requestor.Id);
+        var result = project.AddOrUpdateUserRole(command.UserId, command.AccessLevel, command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/CreateDatasetCommand.cs
+++ b/src/OStats.API/Commands/CreateDatasetCommand.cs
@@ -2,14 +2,14 @@ namespace OStats.API.Commands;
 
 public record CreateDatasetCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public string Title { get; set; }
     public string Source { get; set; }
     public string Description { get; set; }
 
-    public CreateDatasetCommand(string userAuthId, string title, string source, string? description)
+    public CreateDatasetCommand(Guid requestorUserId, string title, string source, string? description)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         Title = title;
         Source = source;
         Description = description ?? string.Empty;

--- a/src/OStats.API/Commands/CreateDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/CreateDatasetCommandHandler.cs
@@ -15,13 +15,7 @@ public sealed class CreateDatasetCommandHandler : CommandHandler<CreateDatasetCo
 
     public override async Task<ValueTuple<DomainOperationResult, BaseDatasetDto?>> Handle(CreateDatasetCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return (DomainOperationResult.Failure("User not found."), null);
-        }
-
-        var dataset = new Dataset(user.Id, command.Title, command.Source, command.Description);
+        var dataset = new Dataset(command.RequestorUserId, command.Title, command.Source, command.Description);
         await _context.AddAsync(dataset, cancellationToken);
         await SaveCommandHandlerChangesAsync(cancellationToken);
 

--- a/src/OStats.API/Commands/CreateProjectCommand.cs
+++ b/src/OStats.API/Commands/CreateProjectCommand.cs
@@ -2,13 +2,13 @@ namespace OStats.API.Commands;
 
 public record CreateProjectCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public string Title { get; set; }
     public string Description { get; set; }
 
-    public CreateProjectCommand(string userAuthId, string title, string? description)
+    public CreateProjectCommand(Guid requestorUserId, string title, string? description)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         Title = title;
         Description = description ?? string.Empty;
     }

--- a/src/OStats.API/Commands/CreateProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/CreateProjectCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed class CreateProjectCommandHandler : CommandHandler<CreateProjectCo
 
     public override async Task<ValueTuple<DomainOperationResult, BaseProjectDto?>> Handle(CreateProjectCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
+        var user = await _context.Users.FindAsync([command.RequestorUserId], cancellationToken);
         if (user is null)
         {
             return (DomainOperationResult.Failure("User not found."), null);

--- a/src/OStats.API/Commands/DeleteDatasetCommand.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommand.cs
@@ -2,12 +2,12 @@ namespace OStats.API.Commands;
 
 public sealed record DeleteDatasetCommand
 {
-    public string UserAuthId { get; }
+    public Guid RequestorUserId { get; }
     public Guid DatasetId { get; }
 
-    public DeleteDatasetCommand(string userAuthId, Guid datasetId)
+    public DeleteDatasetCommand(Guid requestorUserId, Guid datasetId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         DatasetId = datasetId;
     }
 }

--- a/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteDatasetCommandHandler.cs
@@ -14,19 +14,13 @@ public sealed class DeleteDatasetCommandHandler : CommandHandler<DeleteDatasetCo
 
     public override async Task<DomainOperationResult> Handle(DeleteDatasetCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return DomainOperationResult.Failure("User not found.");
-        }
-
         var dataset = await _context.Datasets.FindAsync(command.DatasetId, cancellationToken);
         if (dataset is null)
         {
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        dataset.Delete(user.Id);
+        dataset.Delete(command.RequestorUserId);
         await SaveCommandHandlerChangesAsync(cancellationToken);
 
         return DomainOperationResult.Success;

--- a/src/OStats.API/Commands/DeleteProjectCommand.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommand.cs
@@ -2,12 +2,12 @@ namespace OStats.API.Commands;
 
 public sealed record DeleteProjectCommand
 {
-    public string UserAuthId { get; }
+    public Guid RequestorUserId { get; }
     public Guid ProjectId { get; }
 
-    public DeleteProjectCommand(string userAuthId, Guid projectId)
+    public DeleteProjectCommand(Guid requestorUserId, Guid projectId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         ProjectId = projectId;
     }
 }

--- a/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteProjectCommandHandler.cs
@@ -13,19 +13,13 @@ public sealed class DeleteProjectCommandHandler : CommandHandler<DeleteProjectCo
 
     public override async Task<DomainOperationResult> Handle(DeleteProjectCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return DomainOperationResult.Failure("User not found.");
-        }
-
-        var project = await _context.Projects.FindAsync(command.ProjectId, cancellationToken);
+        var project = await _context.Projects.FindAsync([command.ProjectId], cancellationToken);
         if (project is null)
         {
             return DomainOperationResult.Failure("Project not found.");
         }
 
-        var result = project.Delete(user.Id);
+        var result = project.Delete(command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/DeleteUserCommand.cs
+++ b/src/OStats.API/Commands/DeleteUserCommand.cs
@@ -2,6 +2,6 @@ namespace OStats.API.Commands;
 
 public sealed record DeleteUserCommand
 {
-    public required string UserAuthId { get; init; }
+    public required Guid RequestorUserId { get; init; }
     public required Guid UserId { get; init; }
 }

--- a/src/OStats.API/Commands/DeleteUserCommandHandler.cs
+++ b/src/OStats.API/Commands/DeleteUserCommandHandler.cs
@@ -13,19 +13,13 @@ public sealed class DeleteUserCommandHandler : CommandHandler<DeleteUserCommand,
 
     public override async Task<DomainOperationResult> Handle(DeleteUserCommand command, CancellationToken cancellationToken)
     {
-        var requestor = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found.");
-        }
-
         var toBeDeletedUser = await _context.Users.FindAsync(command.UserId, cancellationToken);
         if (toBeDeletedUser is null)
         {
             return DomainOperationResult.Failure("User not found.");
         }
 
-        var result = toBeDeletedUser.Delete(requestor.Id);
+        var result = toBeDeletedUser.Delete(command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/IngestDataCommand.cs
+++ b/src/OStats.API/Commands/IngestDataCommand.cs
@@ -3,13 +3,13 @@ namespace OStats.API.Commands;
 public sealed record IngestDataCommand
 {
     public Guid DatasetId { get; }
-    public string UserAuthId { get; }
+    public Guid RequestorUserId { get; }
     public string Bucket { get; }
     public string FileName { get; }
 
-    public IngestDataCommand(string userAuthId, Guid datasetId, string bucket, string fileName)
+    public IngestDataCommand(Guid requestorUserId, Guid datasetId, string bucket, string fileName)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         DatasetId = datasetId;
         Bucket = bucket;
         FileName = fileName;

--- a/src/OStats.API/Commands/IngestDataCommandHandler.cs
+++ b/src/OStats.API/Commands/IngestDataCommandHandler.cs
@@ -18,12 +18,6 @@ public sealed class IngestDataCommandHandler : CommandHandler<IngestDataCommand,
 
     public override async Task<DomainOperationResult> Handle(IngestDataCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return DomainOperationResult.Failure("User not found.");
-        }
-
         var dataset = await _context.Datasets.FindAsync(command.DatasetId, cancellationToken);
         if (dataset is null)
         {
@@ -31,7 +25,7 @@ public sealed class IngestDataCommandHandler : CommandHandler<IngestDataCommand,
         }
 
         var minimumAccessLevelRequired = DatasetAccessLevel.Editor;
-        if (dataset.GetUserAccessLevel(user.Id) < minimumAccessLevelRequired)
+        if (dataset.GetUserAccessLevel(command.RequestorUserId) < minimumAccessLevelRequired)
         {
             return DomainOperationResult.Failure("User does not have the required access level.");
         }

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommand .cs
@@ -2,12 +2,12 @@ namespace OStats.API.Commands;
 
 public sealed record LinkProjectToDatasetCommand
 {
-    public string UserAuthId { get; }
+    public Guid RequestorUserId { get; }
     public Guid DatasetId { get; }
     public Guid ProjectId { get; }
-    public LinkProjectToDatasetCommand(string userAuthId, Guid datasetId, Guid projectId)
+    public LinkProjectToDatasetCommand(Guid requestorUserId, Guid datasetId, Guid projectId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         DatasetId = datasetId;
         ProjectId = projectId;
     }

--- a/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/LinkProjectToDatasetCommandHandler.cs
@@ -13,12 +13,6 @@ public sealed class LinkProjectToDatasetCommandHandler : CommandHandler<LinkProj
 
     public override async Task<DomainOperationResult> Handle(LinkProjectToDatasetCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return DomainOperationResult.Failure("User not found.");
-        }
-
         var project = await _context.Projects.FindAsync(command.ProjectId, cancellationToken);
         if (project is null)
         {
@@ -31,7 +25,7 @@ public sealed class LinkProjectToDatasetCommandHandler : CommandHandler<LinkProj
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        var result = project.LinkDataset(dataset.Id, user.Id);
+        var result = project.LinkDataset(dataset.Id, command.RequestorUserId);
 
         if (!result.Succeeded)
         {

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommand.cs
@@ -2,13 +2,13 @@ namespace OStats.API.Commands;
 
 public sealed record RemoveUserFromDatasetCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public Guid DatasetId { get; set; }
     public Guid UserId { get; set; }
 
-    public RemoveUserFromDatasetCommand(string userAuthId, Guid datasetId, Guid userId)
+    public RemoveUserFromDatasetCommand(Guid requestorUserId, Guid datasetId, Guid userId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         DatasetId = datasetId;
         UserId = userId;
     }

--- a/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromDatasetCommandHandler.cs
@@ -11,21 +11,15 @@ public sealed class RemoveUserFromDatasetCommandHandler : CommandHandler<RemoveU
     {
     }
 
-    public override async Task<DomainOperationResult> Handle(RemoveUserFromDatasetCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(RemoveUserFromDatasetCommand command, CancellationToken cancellationToken)
     {
-        var dataset = await _context.Datasets.FindAsync(request.DatasetId, cancellationToken);
+        var dataset = await _context.Datasets.FindAsync(command.DatasetId, cancellationToken);
         if (dataset is null)
         {
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found.");
-        }
-
-        var result = dataset.RemoveUserAccess(request.UserId, requestor.Id);
+        var result = dataset.RemoveUserAccess(command.UserId, command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommand.cs
@@ -2,13 +2,13 @@ namespace OStats.API.Commands;
 
 public sealed record RemoveUserFromProjectCommand
 {
-    public string UserAuthId { get; set; }
+    public Guid RequestorUserId { get; set; }
     public Guid ProjectId { get; set; }
     public Guid UserId { get; set; }
 
-    public RemoveUserFromProjectCommand(string userAuthId, Guid projectId, Guid userId)
+    public RemoveUserFromProjectCommand(Guid requestorUserId, Guid projectId, Guid userId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         ProjectId = projectId;
         UserId = userId;
     }

--- a/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/RemoveUserFromProjectCommandHandler.cs
@@ -11,22 +11,15 @@ public sealed class RemoveUserFromProjectCommandHandler : CommandHandler<RemoveU
     {
     }
 
-    public override async Task<DomainOperationResult> Handle(RemoveUserFromProjectCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(RemoveUserFromProjectCommand command, CancellationToken cancellationToken)
     {
-
-        var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found.");
-        }
-
-        var project = await _context.Projects.FindAsync(request.ProjectId);
+        var project = await _context.Projects.FindAsync([command.ProjectId], cancellationToken);
         if (project is null)
         {
             return DomainOperationResult.Failure("Project not found.");
         }
 
-        var result = project.RemoveUserRole(request.UserId, requestor.Id);
+        var result = project.RemoveUserRole(command.UserId, command.RequestorUserId);
 
         if (!result.Succeeded)
         {

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommand.cs
@@ -2,12 +2,12 @@ namespace OStats.API.Commands;
 
 public sealed record UnlinkProjectToDatasetCommand
 {
-    public string UserAuthId { get; }
+    public Guid RequestorUserId { get; }
     public Guid DatasetId { get; }
     public Guid ProjectId { get; }
-    public UnlinkProjectToDatasetCommand(string userAuthId, Guid datasetId, Guid projectId)
+    public UnlinkProjectToDatasetCommand(Guid requestorUserId, Guid datasetId, Guid projectId)
     {
-        UserAuthId = userAuthId;
+        RequestorUserId = requestorUserId;
         DatasetId = datasetId;
         ProjectId = projectId;
     }

--- a/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/UnlinkProjectToDatasetCommandHandler.cs
@@ -13,25 +13,19 @@ public sealed class UnlinkProjectToDatasetCommandHandler : CommandHandler<Unlink
 
     public override async Task<DomainOperationResult> Handle(UnlinkProjectToDatasetCommand command, CancellationToken cancellationToken)
     {
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
-        if (user is null)
-        {
-            return DomainOperationResult.Failure("User not found.");
-        }
-
-        var project = await _context.Projects.FindAsync(command.ProjectId);
+        var project = await _context.Projects.FindAsync([command.ProjectId], cancellationToken);
         if (project is null)
         {
             return DomainOperationResult.Failure("Project not found.");
         }
 
-        var dataset = await _context.Datasets.FindAsync(command.DatasetId);
+        var dataset = await _context.Datasets.FindAsync([command.DatasetId], cancellationToken);
         if (dataset is null)
         {
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        var result = project.UnlinkDataset(dataset.Id, user.Id);
+        var result = project.UnlinkDataset(dataset.Id, command.RequestorUserId);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/UpdateDatasetCommand.cs
+++ b/src/OStats.API/Commands/UpdateDatasetCommand.cs
@@ -5,7 +5,7 @@ public sealed record UpdateDatasetCommand : CreateDatasetCommand
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }
 
-    public UpdateDatasetCommand(Guid id, string userAuthId, string title, string source, DateTime lastUpdatedAt, string? description) : base(userAuthId, title, source, description)
+    public UpdateDatasetCommand(Guid id, Guid requestorUserId, string title, string source, DateTime lastUpdatedAt, string? description) : base(requestorUserId, title, source, description)
     {
         Id = id;
         LastUpdatedAt = lastUpdatedAt;

--- a/src/OStats.API/Commands/UpdateDatasetCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateDatasetCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed class UpdateDatasetCommandHandler : CommandHandler<UpdateDatasetCo
 
     public override async Task<ValueTuple<DomainOperationResult, BaseDatasetDto?>> Handle(UpdateDatasetCommand command, CancellationToken cancellationToken)
     {
-        var dataset = await _context.Datasets.FindAsync(command.Id, cancellationToken);
+        var dataset = await _context.Datasets.FindAsync([command.Id], cancellationToken);
         if (dataset is null)
         {
             return (DomainOperationResult.Failure("Dataset not found."), null);
@@ -26,7 +26,7 @@ public sealed class UpdateDatasetCommandHandler : CommandHandler<UpdateDatasetCo
             return (DomainOperationResult.Failure("Project has changed since command was submited."), null);
         }
 
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
+        var user = await _context.Users.FindAsync([command.RequestorUserId], cancellationToken);
         if (user is null)
         {
             return (DomainOperationResult.Failure("User not found."), null);

--- a/src/OStats.API/Commands/UpdateDatasetVisibilityCommand.cs
+++ b/src/OStats.API/Commands/UpdateDatasetVisibilityCommand.cs
@@ -3,6 +3,6 @@ namespace OStats.API.Commands;
 public sealed record UpdateDatasetVisibilityCommand
 {
     public required Guid DatasetId { get; init; }
-    public required string UserAuthId { get; init; }
+    public required Guid RequestorUserId { get; init; }
     public required bool IsPublic { get; init; }
 }

--- a/src/OStats.API/Commands/UpdateDatasetVisibilityCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateDatasetVisibilityCommandHandler.cs
@@ -11,21 +11,15 @@ public sealed class UpdateDatasetVisibilityCommandHandler : CommandHandler<Updat
     {
     }
 
-    public override async Task<DomainOperationResult> Handle(UpdateDatasetVisibilityCommand request, CancellationToken cancellationToken)
+    public override async Task<DomainOperationResult> Handle(UpdateDatasetVisibilityCommand command, CancellationToken cancellationToken)
     {
-        var dataset = await _context.Datasets.FindAsync(request.DatasetId, cancellationToken);
+        var dataset = await _context.Datasets.FindAsync([command.DatasetId], cancellationToken);
         if (dataset is null)
         {
             return DomainOperationResult.Failure("Dataset not found.");
         }
 
-        var requestor = await _context.Users.FindByAuthIdentityAsync(request.UserAuthId, cancellationToken);
-        if (requestor is null)
-        {
-            return DomainOperationResult.Failure("Requestor not found.");
-        }
-
-        var result = dataset.UpdateVisibility(requestor.Id, request.IsPublic);
+        var result = dataset.UpdateVisibility(command.RequestorUserId, command.IsPublic);
         if (!result.Succeeded)
         {
             return result;

--- a/src/OStats.API/Commands/UpdateProjectCommand.cs
+++ b/src/OStats.API/Commands/UpdateProjectCommand.cs
@@ -5,7 +5,7 @@ public sealed record UpdateProjectCommand : CreateProjectCommand
     public Guid Id { get; init; }
     public DateTime LastUpdatedAt { get; init; }
 
-    public UpdateProjectCommand(Guid id, string userAuthId, string title, DateTime lastUpdatedAt, string? description) : base(userAuthId, title, description)
+    public UpdateProjectCommand(Guid id, Guid requestorUserId, string title, DateTime lastUpdatedAt, string? description) : base(requestorUserId, title, description)
     {
         Id = id;
         LastUpdatedAt = lastUpdatedAt;

--- a/src/OStats.API/Commands/UpdateProjectCommandHandler.cs
+++ b/src/OStats.API/Commands/UpdateProjectCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed class UpdateProjectCommandHandler : CommandHandler<UpdateProjectCo
 
     public override async Task<ValueTuple<DomainOperationResult, BaseProjectDto?>> Handle(UpdateProjectCommand command, CancellationToken cancellationToken)
     {
-        var project = await _context.Projects.FindAsync(command.Id, cancellationToken);
+        var project = await _context.Projects.FindAsync([command.Id], cancellationToken);
         if (project is null)
         {
             return (DomainOperationResult.Failure("Project not found."), null);
@@ -26,7 +26,7 @@ public sealed class UpdateProjectCommandHandler : CommandHandler<UpdateProjectCo
             return (DomainOperationResult.Failure("Project has changed since command was submited."), null);
         }
 
-        var user = await _context.Users.FindByAuthIdentityAsync(command.UserAuthId, cancellationToken);
+        var user = await _context.Users.FindAsync([command.RequestorUserId], cancellationToken);
         if (user is null)
         {
             return (DomainOperationResult.Failure("User not found."), null);

--- a/src/OStats.API/Common/UserContext.cs
+++ b/src/OStats.API/Common/UserContext.cs
@@ -1,0 +1,34 @@
+using OStats.API.Extensions;
+using OStats.Domain.Aggregates.UserAggregate;
+using OStats.Infrastructure;
+
+namespace OStats.API.Common;
+
+public sealed class UserContext
+{
+    private readonly HttpContext _httpContext;
+    private readonly Context _context;
+    private User? _user;
+
+    public UserContext(IHttpContextAccessor httpContextAccessor, Context context)
+    {
+        _httpContext = httpContextAccessor.HttpContext ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<User> GetCurrentUserAsync(CancellationToken cancellationToken)
+    {
+        if (_user is not null)
+        {
+            return await Task.FromResult(_user);
+        }
+
+        _user = await _context.Users.FindByAuthIdentityAsync(_httpContext.GetUserAuthId(), cancellationToken);
+        return _user!;
+    }
+
+    public async Task<Guid> GetCurrentUserIdAsync(CancellationToken cancellationToken)
+    {
+        return (await GetCurrentUserAsync(cancellationToken)).Id;
+    }
+}

--- a/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OStats.API/Extensions/ServiceCollectionExtensions.cs
@@ -5,12 +5,20 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using OStats.API.Commands.Common;
+using OStats.API.Common;
 using OStats.Infrastructure;
 
 namespace OStats.API.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    public static IServiceCollection AddUserContext(this IServiceCollection services)
+    {
+        services.AddHttpContextAccessor();
+        services.AddScoped<UserContext>();
+        return services;
+    }
+
     public static IServiceCollection AddCommandHandlers(this IServiceCollection services)
     {
         var commandHandlerType = typeof(CommandHandler<,>);

--- a/src/OStats.API/Middlewares/UserContextMiddleware.cs
+++ b/src/OStats.API/Middlewares/UserContextMiddleware.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using OStats.API.Common;
+
+namespace OStats.API.Middlewares;
+
+public sealed class UserContextMiddleware
+{
+    private readonly RequestDelegate _next;
+    public static readonly string ByPassUserContextMiddleware = "ByPassUserContextMiddleware";
+
+    public UserContextMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, UserContext userContext)
+    {
+        if (context.GetEndpoint()?.Metadata.GetMetadata<string>() == ByPassUserContextMiddleware)
+        {
+            await _next(context);
+            return;
+        }
+
+        var user = await userContext.GetCurrentUserAsync(context.RequestAborted);
+        if (user is not null)
+        {
+            await _next(context);
+            return;
+        }
+
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(new { message = "User not found." }));
+    }
+}

--- a/src/OStats.API/Program.cs
+++ b/src/OStats.API/Program.cs
@@ -2,6 +2,7 @@ using OStats.API;
 using OStats.API.Extensions;
 using OStats.Infrastructure;
 using DataServiceGrpc;
+using OStats.API.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,6 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddJwtBearerAuthentication();
 builder.Services.AddAuthorization();
 builder.Services.AddDbContext<Context>();
+builder.Services.AddUserContext();
 builder.Services.AddGrpcClient<DataService.DataServiceClient>(o =>
 {
     o.Address = new Uri("http://dataservice:50051");
@@ -26,6 +28,7 @@ app.UseSwaggerUI();
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<UserContextMiddleware>();
 
 app.MapGroup("/v1/datasets").WithTags(["Datasets"]).MapDatasetsApi().RequireAuthorization();
 app.MapGroup("/v1/projects").WithTags(["Projects"]).MapProjectsApi().RequireAuthorization();

--- a/src/OStats.API/Queries/UserQueries.cs
+++ b/src/OStats.API/Queries/UserQueries.cs
@@ -16,7 +16,7 @@ public static class UserQueries
             .ToListAsync(cancellationToken);
     }
 
-    public static Task<List<UserProjectDto>> GetUserProjectsAsync(Context context, string userAuthId, Guid userId, CancellationToken cancellationToken)
+    public static Task<List<UserProjectDto>> GetUserProjectsAsync(Context context, Guid requestorUserId, Guid userId, CancellationToken cancellationToken)
     {
         return context.Roles
             .Join(
@@ -29,7 +29,7 @@ public static class UserQueries
                 roleAndUser => roleAndUser.role.ProjectId,
                 project => project.Id,
                 (roleAndUser, project) => new { project, roleAndUser })
-            .Where(join => join.roleAndUser.user.AuthIdentity == userAuthId &&
+            .Where(join => join.roleAndUser.user.Id == requestorUserId &&
                            join.roleAndUser.user.Id == userId)
             .Select(join => new UserProjectDto(join.project, join.roleAndUser.role))
             .AsNoTracking()
@@ -64,7 +64,7 @@ public static class UserQueries
                 .SingleOrDefault()
     );
 
-    public static Task<List<UserDatasetDto>> GetUserDatasetsAsync(Context context, string userAuthId, Guid userId, CancellationToken cancellationToken)
+    public static Task<List<UserDatasetDto>> GetUserDatasetsAsync(Context context, Guid requestorUserId, Guid userId, CancellationToken cancellationToken)
     {
         return context.DatasetsUsersAccessLevels
             .Join(
@@ -78,7 +78,7 @@ public static class UserQueries
                 user => user.Id,
                 (datasetAndUserId, user) => new { datasetAndUserId, user })
             .Where(joined => joined.datasetAndUserId.userAccess.UserId == userId &&
-                                joined.user.AuthIdentity == userAuthId)
+                                joined.user.Id == requestorUserId)
             .Select(join => new UserDatasetDto(join.datasetAndUserId.dataset, join.datasetAndUserId.userAccess))
             .AsNoTracking()
             .ToListAsync(cancellationToken);

--- a/src/OStats.Tests/IntegrationTests/Commands/AddUserToProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/AddUserToProjectIntegrationTest.cs
@@ -24,7 +24,7 @@ public class AddUserToProjectIntegrationTest : BaseIntegrationTest
         await context.SaveChangesAsync();
         var access = AccessLevel.ReadOnly;
 
-        var command = new AddUserToProjectCommand(owner.AuthIdentity, project.Id, user.Id, access);
+        var command = new AddUserToProjectCommand(owner.Id, project.Id, user.Id, access);
         var result = await serviceProvider.GetRequiredService<AddUserToProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())

--- a/src/OStats.Tests/IntegrationTests/Commands/CreateProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/CreateProjectIntegrationTest.cs
@@ -17,7 +17,7 @@ public class CreateProjectIntegrationTest : BaseIntegrationTest
     {
         var beforeCommandTime = DateTime.UtcNow;
         var existingUser = await context.Users.FirstAsync();
-        var command = new CreateProjectCommand(existingUser.AuthIdentity, "Test", "Test");
+        var command = new CreateProjectCommand(existingUser.Id, "Test", "Test");
         var (result, baseProjectDto) = await serviceProvider.GetRequiredService<CreateProjectCommandHandler>().Handle(command, default);
         var afterCommandTime = DateTime.UtcNow;
 
@@ -33,9 +33,10 @@ public class CreateProjectIntegrationTest : BaseIntegrationTest
     }
 
     [Fact]
-    public async Task Should_Fail_If_User_Does_Not_Exists()
+    public async Task Should_Throw_If_User_Does_Not_Exists()
     {
-        var command = new CreateProjectCommand("Test", "test@test.com", "An authid that clearly doesnt exist");
+        var command = new CreateProjectCommand(Guid.NewGuid(), "test@test.com", "An authid that clearly doesnt exist");
+
         var (result, baseProjectDto) = await serviceProvider.GetRequiredService<CreateProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())

--- a/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/DeleteProjectIntegrationTest.cs
@@ -23,7 +23,7 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
         await context.AddAsync(user);
         project.AddOrUpdateUserRole(user.Id, AccessLevel.Editor, ownerId);
         await context.SaveChangesAsync();
-        var command = new DeleteProjectCommand(user.AuthIdentity, project.Id);
+        var command = new DeleteProjectCommand(user.Id, project.Id);
         var result = await serviceProvider.GetRequiredService<DeleteProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
@@ -43,7 +43,7 @@ public class DeleteProjectIntegrationTest : BaseIntegrationTest
         await context.Projects.AddAsync(project);
         await context.SaveChangesAsync();
 
-        var command = new DeleteProjectCommand(existingUser.AuthIdentity, project.Id);
+        var command = new DeleteProjectCommand(existingUser.Id, project.Id);
         var result = await serviceProvider.GetRequiredService<DeleteProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())

--- a/src/OStats.Tests/IntegrationTests/Commands/UpdateProjectIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Commands/UpdateProjectIntegrationTest.cs
@@ -25,7 +25,7 @@ public class UpdateProjectIntegrationTest : BaseIntegrationTest
         var previousLastUpdatedAtDatetime = project.LastUpdatedAt;
         var editedTitle = "Edited Title";
         var editedDescription = "Edited description";
-        var command = new UpdateProjectCommand(project.Id, user.AuthIdentity, editedTitle, project.LastUpdatedAt, editedDescription);
+        var command = new UpdateProjectCommand(project.Id, user.Id, editedTitle, project.LastUpdatedAt, editedDescription);
         var (result, baseProjectDto) = await serviceProvider.GetRequiredService<UpdateProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())
@@ -53,7 +53,7 @@ public class UpdateProjectIntegrationTest : BaseIntegrationTest
         var editedDescription = "Edited description";
         project.SetTitle("Bypassed edition", project.Roles.GetUserRole(user.Id)!);
         await context.SaveChangesAsync();
-        var command = new UpdateProjectCommand(project.Id, user.AuthIdentity, editedTitle, previousLastUpdatedAtDatetime, editedDescription);
+        var command = new UpdateProjectCommand(project.Id, user.Id, editedTitle, previousLastUpdatedAtDatetime, editedDescription);
         var (result, baseProjectDto) = await serviceProvider.GetRequiredService<UpdateProjectCommandHandler>().Handle(command, default);
 
         using (new AssertionScope())

--- a/src/OStats.Tests/IntegrationTests/Queries/DatasetByIdQueryIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Queries/DatasetByIdQueryIntegrationTest.cs
@@ -23,7 +23,7 @@ public class DatasetByIdQueryIntegrationTest : BaseIntegrationTest
         dataset.GrantUserAccess(editor.Id, DatasetAccessLevel.Editor, owner.Id);
         await context.SaveChangesAsync();
 
-        var queriedDataset = await DatasetQueries.GetDatasetByIdAsync(context, owner.AuthIdentity, dataset.Id, default);
+        var queriedDataset = await DatasetQueries.GetDatasetByIdAsync(context, owner.Id, dataset.Id, default);
         using (new AssertionScope())
         {
             queriedDataset.Should().NotBeNull();
@@ -46,7 +46,7 @@ public class DatasetByIdQueryIntegrationTest : BaseIntegrationTest
 
         await context.SaveChangesAsync();
 
-        var queriedDataset = await DatasetQueries.GetDatasetByIdAsync(context, unauthorizedUser.AuthIdentity, dataset.Id, default);
+        var queriedDataset = await DatasetQueries.GetDatasetByIdAsync(context, unauthorizedUser.Id, dataset.Id, default);
         queriedDataset.Should().BeNull();
     }
 }

--- a/src/OStats.Tests/IntegrationTests/Queries/ProjectByIdQueryIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Queries/ProjectByIdQueryIntegrationTest.cs
@@ -20,7 +20,7 @@ public class ProjectByIdQueryIntegrationTest : BaseIntegrationTest
         await context.Projects.AddAsync(project);
         await context.SaveChangesAsync();
 
-        var queriedProject = await ProjectQueries.GetProjectByIdAsync(context, user.AuthIdentity, project.Id, default);
+        var queriedProject = await ProjectQueries.GetProjectByIdAsync(context, user.Id, project.Id, default);
 
         using(new AssertionScope())
         {
@@ -41,7 +41,7 @@ public class ProjectByIdQueryIntegrationTest : BaseIntegrationTest
         await context.AddAsync(unauthorized);
         await context.SaveChangesAsync();
 
-        var queriedProject = await ProjectQueries.GetProjectByIdAsync(context, unauthorized.AuthIdentity, project.Id, default);
+        var queriedProject = await ProjectQueries.GetProjectByIdAsync(context, unauthorized.Id, project.Id, default);
 
         queriedProject.Should().BeNull();
     }

--- a/src/OStats.Tests/IntegrationTests/Queries/UserDatasetsWithAccessQueryIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Queries/UserDatasetsWithAccessQueryIntegrationTest.cs
@@ -36,7 +36,7 @@ public class UserDatasetsWithAccessQueryIntegrationTest : BaseIntegrationTest
 
         await context.SaveChangesAsync();
 
-        var queriedUserDatasets = await UserQueries.GetUserDatasetsAsync(context, user.AuthIdentity, user.Id, default);
+        var queriedUserDatasets = await UserQueries.GetUserDatasetsAsync(context, user.Id, user.Id, default);
 
         queriedUserDatasets.Should().AllBeOfType<UserDatasetDto>();
         queriedUserDatasets.Should().HaveCount(2);

--- a/src/OStats.Tests/IntegrationTests/Queries/UserProjectsWithRoleQueryIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Queries/UserProjectsWithRoleQueryIntegrationTest.cs
@@ -35,7 +35,7 @@ public class UserProjectsWithRoleQueryIntegrationTest : BaseIntegrationTest
 
         await context.SaveChangesAsync();
 
-        var queriedUserProjects = await UserQueries.GetUserProjectsAsync(context, user.AuthIdentity, user.Id, default);
+        var queriedUserProjects = await UserQueries.GetUserProjectsAsync(context, user.Id, user.Id, default);
 
         queriedUserProjects.Should().AllBeOfType<UserProjectDto>();
         queriedUserProjects.Should().HaveCount(2);


### PR DESCRIPTION
This pull request includes significant changes to the `src/OStats.API/Apis` directory, primarily focusing on refactoring the API handlers to use `UserContext` for retrieving user information. This change aims to improve the consistency and security of user data access across the application.

Refactoring to use `UserContext`:

* [`src/OStats.API/Apis/DatasetsApi.cs`](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL36-R53): Replaced `HttpContext` with `UserContext` in various handlers to retrieve user information. [[1]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL36-R53) [[2]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL65-R109) [[3]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL137-R145) [[4]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL154-R159) [[5]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bL172-R190)
* [`src/OStats.API/Apis/ProjectsApi.cs`](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L31-R49): Updated handlers to use `UserContext` instead of `HttpContext` for user data retrieval. [[1]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L31-R49) [[2]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L61-R90) [[3]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84L103-R147)
* [`src/OStats.API/Apis/UsersApi.cs`](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L28-R37): Refactored to utilize `UserContext` for user-related operations, and added middleware metadata for bypassing user context where necessary. [[1]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L28-R37) [[2]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L49-R58) [[3]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0L77-R97)

Other changes:

* Added `OStats.API.Common` namespace import to multiple files for consistent access to common utilities. [[1]](diffhunk://#diff-4757b2b21417cc20e614fcd383c2362a704cad7d04ac9a359ce941c61126833bR7-L8) [[2]](diffhunk://#diff-a2e6d1261cf27686c6337d9877cd10e4b91aacf3c54756d8d715bf319349ef84R4) [[3]](diffhunk://#diff-780c62fe5c6773790497f17639cb96d2392cf046b2547a5870d67dd80cb352b0R4-R8)
* Included `UserContextMiddleware.ByPassUserContextMiddleware` metadata in `UsersApi` to selectively bypass user context middleware for specific endpoints.