### PR TITLE
tests: refactor integration tests factory, extends http client, simplified entity id

### DIFF
--- a/src/OStats.API/Dtos/DatasetUserAccessLevelsDto.cs
+++ b/src/OStats.API/Dtos/DatasetUserAccessLevelsDto.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using OStats.Domain.Aggregates.DatasetAggregate;
 using OStats.Domain.Aggregates.UserAggregate;
 
@@ -7,9 +8,12 @@ public record DatasetUserAccessLevelsDto : BaseEntityDto
 {
     public BaseUserDto User { get; }
     public DatasetAccessLevel DatasetAccessLevel { get; }
+
+    [JsonConstructor]
     public DatasetUserAccessLevelsDto(User user, DatasetUserAccessLevel datasetUserAccessLevel) : base(datasetUserAccessLevel)
     {
         DatasetAccessLevel = datasetUserAccessLevel.AccessLevel;
         User = new BaseUserDto(user);
     }
+
 }

--- a/src/OStats.Domain/Common/Entity.cs
+++ b/src/OStats.Domain/Common/Entity.cs
@@ -7,18 +7,7 @@ namespace OStats.Domain.Common;
 public abstract class Entity
 {
     private Guid _id;
-    public virtual Guid Id
-    {
-        get
-        {
-            return _id;
-        }
-        protected set
-        {
-            _id = value;
-        }
-    }
-
+    public virtual Guid Id { get => _id; protected set => _id = value; }
     public DateTime CreatedAt { get; internal set; }
     public DateTime LastUpdatedAt { get; internal set; }
     public bool IsDeleted { get; internal set; }

--- a/src/OStats.Tests/IntegrationTests/Apis/UsersApiIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/Apis/UsersApiIntegrationTest.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FluentAssertions.Execution;
 using MassTransit.Testing;
@@ -35,10 +34,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var validUser = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(validUser.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.GetAsync($"{_base_url}?search={validUser.Name}");
+        var response = await client
+            .WithJwtBearerTokenForUser(validUser)
+            .GetAsync($"{_base_url}?search={validUser.Name}");
         var results = await response.Content.ReadFromJsonAsync<List<BaseUserDto>>();
 
         using (new AssertionScope())
@@ -54,10 +52,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var validUser = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(validUser.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.GetAsync($"{_base_url}/{validUser.Id}");
+        var response = await client
+            .WithJwtBearerTokenForUser(validUser)
+            .GetAsync($"{_base_url}/{validUser.Id}");
         var result = await response.Content.ReadFromJsonAsync<BaseUserDto>();
 
         using (new AssertionScope())
@@ -77,10 +74,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
             Email = "test@test.com"
         };
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId("test|user_create_test");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.PostAsJsonAsync(_base_url, userDto);
+        var response = await client
+            .WithJwtBearerTokenForAuthId("test|user_create_test")
+            .PostAsJsonAsync(_base_url, userDto);
         var result = await response.Content.ReadFromJsonAsync<BaseUserDto>();
 
         using (new AssertionScope())
@@ -98,10 +94,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var validUser = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(validUser.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.PostAsJsonAsync(_base_url, userDto);
+        var response = await client
+            .WithJwtBearerTokenForUser(validUser)
+            .PostAsJsonAsync(_base_url, userDto);
 
         using (new AssertionScope())
         {
@@ -114,10 +109,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var validUser = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(validUser.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.GetAsync($"{_base_url}/{validUser.Id}/projects");
+        var response = await client
+            .WithJwtBearerTokenForUser(validUser)
+            .GetAsync($"{_base_url}/{validUser.Id}/projects");
         var userProjects = await response.Content.ReadFromJsonAsync<IEnumerable<object>>();
 
         using (new AssertionScope())
@@ -132,10 +126,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var validUser = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(validUser.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.GetAsync($"{_base_url}/{validUser.Id}/datasets");
+        var response = await client
+            .WithJwtBearerTokenForUser(validUser)
+            .GetAsync($"{_base_url}/{validUser.Id}/datasets");
         var userDatasets = await response.Content.ReadFromJsonAsync<IEnumerable<object>>();
 
         using (new AssertionScope())
@@ -150,10 +143,9 @@ public class UsersApiIntegrationTest : BaseIntegrationTest
     {
         var user = await context.Users.FirstAsync();
 
-        var token = JwtTokenProvider.GenerateTokenForAuthId(user.AuthIdentity);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.DeleteAsync($"{_base_url}/{user.Id}");
+        var response = await client
+            .WithJwtBearerTokenForUser(user)
+            .DeleteAsync($"{_base_url}/{user.Id}");
 
         await Task.Delay(5 * 1000);
 

--- a/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
+++ b/src/OStats.Tests/IntegrationTests/BaseIntegrationTest.cs
@@ -1,9 +1,6 @@
 using MassTransit.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using OStats.Domain.Aggregates.DatasetAggregate;
-using OStats.Domain.Aggregates.ProjectAggregate;
-using OStats.Domain.Aggregates.UserAggregate;
 using OStats.Infrastructure;
 
 namespace OStats.Tests.IntegrationTests;
@@ -21,30 +18,10 @@ public abstract class BaseIntegrationTest : IClassFixture<IntegrationTestWebAppF
         _scope = factory.Services.CreateScope();
         serviceProvider = _scope.ServiceProvider;
         context = _scope.ServiceProvider.GetRequiredService<Context>();
+        context.Database.MigrateAsync().Wait();
         queueHarness = _scope.ServiceProvider.GetTestHarness();
         client = factory.CreateClient();
-
-        SetDatabaseInitialState();
         queueHarness.Start();
-    }
-
-    private void SetDatabaseInitialState()
-    {
-        context.Database.Migrate();
-        if (context.Users.Any())
-        {
-            return;
-        }
-
-        var user = new User("Test", "test@test.com", "test_auth_identity");
-        context.Add(user);
-
-        var project = new Project(user.Id, "Test", "Test");
-        context.Add(project);
-        var dataset = new Dataset(user.Id, "Test", "Test", "Test");
-        context.Add(dataset);
-        project.LinkDataset(dataset.Id, user.Id);
-        context.SaveChanges();
     }
 
     public void Dispose()

--- a/src/OStats.Tests/IntegrationTests/DatabaseSeeding.cs
+++ b/src/OStats.Tests/IntegrationTests/DatabaseSeeding.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using OStats.Domain.Aggregates.DatasetAggregate;
+using OStats.Domain.Aggregates.ProjectAggregate;
+using OStats.Domain.Aggregates.UserAggregate;
+
+namespace OStats.Tests.IntegrationTests;
+
+public static class DatabaseSeeding
+{
+    public static Func<DbContext, bool, CancellationToken, Task> SeedAsync = async (context, _, cancellationToken) =>
+    {
+        if (await context.Set<User>().AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        await SeedUsersAsync(context, cancellationToken);
+        await SeedProjectsAsync(context, cancellationToken);
+        await SeedDatasetsAsync(context, cancellationToken);
+        await SeedProjectDatasetLinkAsync(context, cancellationToken);
+    };
+
+    private static async Task SeedUsersAsync(DbContext context, CancellationToken cancellationToken)
+    {
+        var user = new User("Test", "test@test.com", "test_auth_identity");
+        await context.Set<User>().AddAsync(user, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task SeedProjectsAsync(DbContext context, CancellationToken cancellationToken)
+    {
+        var user = await context.Set<User>().FirstAsync(cancellationToken);
+        var project = new Project(user.Id, "Test", "Test");
+        await context.Set<Project>().AddAsync(project, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task SeedDatasetsAsync(DbContext context, CancellationToken cancellationToken)
+    {
+        var user = await context.Set<User>().FirstAsync(cancellationToken);
+        var dataset = new Dataset(user.Id, "Test", "Test", "Test");
+        await context.Set<Dataset>().AddAsync(dataset, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task SeedProjectDatasetLinkAsync(DbContext context, CancellationToken cancellationToken)
+    {
+        var user = await context.Set<User>().FirstAsync(cancellationToken);
+        var project = await context.Set<Project>().FirstAsync(cancellationToken);
+        var dataset = await context.Set<Dataset>().FirstAsync(cancellationToken);
+        project.LinkDataset(dataset.Id, user.Id);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/OStats.Tests/IntegrationTests/HttpClientExtensions.cs
+++ b/src/OStats.Tests/IntegrationTests/HttpClientExtensions.cs
@@ -1,13 +1,28 @@
 using System.Net.Http.Headers;
+using OStats.Domain.Aggregates.UserAggregate;
 
 namespace OStats.Tests.IntegrationTests;
 
 public static class HttpClientExtensions{
-    public static HttpClient WithJwtBearerToken(this HttpClient client, Action<TestJwtToken> configure)
+
+    public static HttpClient WithJwtBearerTokenForUser(this HttpClient client, User user)
     {
-        var token = new TestJwtToken();
-        configure(token);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Build());
+        var token = JwtTokenProvider.GenerateTokenForAuthId(user.AuthIdentity);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    public static HttpClient WithJwtBearerTokenForAuthId(this HttpClient client, string authId)
+    {
+        var token = JwtTokenProvider.GenerateTokenForAuthId(authId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    public static HttpClient WithInvalidJwtBearerToken(this HttpClient client)
+    {
+        var token = JwtTokenProvider.GenerateTokenForInvalidUser();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return client;
     }
 }

--- a/src/OStats.Tests/IntegrationTests/JwtToken.cs
+++ b/src/OStats.Tests/IntegrationTests/JwtToken.cs
@@ -26,12 +26,6 @@ public class TestJwtToken
         return this;
     }
 
-    public TestJwtToken WithDepartment(string department)
-    {
-        Claims.Add(new Claim("department", department));
-        return this;
-    }
-
     public TestJwtToken WithExpiration(int expiresInMinutes)
     {
         ExpiresInMinutes = expiresInMinutes;

--- a/src/OStats.Tests/OStats.Tests.csproj
+++ b/src/OStats.Tests/OStats.Tests.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="..\OStats.API\OStats.API.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/OStats.Tests/xunit.runner.json
+++ b/src/OStats.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "maxParallelThreads": "0.5x"
+}


### PR DESCRIPTION
This pull request includes several changes to the `OStats` project, focusing on improving the integration tests and simplifying the codebase. The most important changes involve refactoring the integration tests to use a new method for setting JWT bearer tokens, adding new test cases, and simplifying property accessors.

### Integration Test Improvements:
* [`src/OStats.Tests/IntegrationTests/Apis/DatasetsApiIntegrationTest.cs`](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL61-R62): Refactored multiple test methods to use `WithJwtBearerTokenForUser` and `WithInvalidJwtBearerToken` methods for setting JWT bearer tokens. Added a new test case `Should_Return_Not_Found_For_Datasets_That_Do_Not_Exist` and `Should_Fail_To_Ingest_Data_If_Dataset_Does_Not_Exists`. [[1]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL61-R62) [[2]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL89-R89) [[3]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebR100-R113) [[4]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL115-R126) [[5]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL152-R162) [[6]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL188-R197) [[7]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL233-R241) [[8]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL263-R270) [[9]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL281-R288) [[10]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebL304-R310) [[11]](diffhunk://#diff-675d37e307fe16b4d960af31e178fd95dbf5cae80e3e2430d23a55508567b6ebR329-R344)

* [`src/OStats.Tests/IntegrationTests/Apis/ProjectsApiIntegrationTest.cs`](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL36-R36): Refactored multiple test methods to use `WithJwtBearerTokenForUser` and `WithInvalidJwtBearerToken` methods for setting JWT bearer tokens. [[1]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL36-R36) [[2]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL62-R61) [[3]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL76-R74) [[4]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL97-R94) [[5]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL115-R112) [[6]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL136-R132) [[7]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL173-R168) [[8]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL204-R198) [[9]](diffhunk://#diff-8287e822b6a01fe7cd0a06cc7a1861ecb8d6c9548d7e1bdb61634ec7fb32e68fL237-R230)

### Codebase Simplification:
* [`src/OStats.Domain/Common/Entity.cs`](diffhunk://#diff-4cb527017df920fba2891bc94a24d054fe03a80eacccb49707b6eef06c67f81dL10-R10): Simplified the `Id` property accessor to use an expression-bodied member.

### DTO Enhancements:
* [`src/OStats.API/Dtos/DatasetUserAccessLevelsDto.cs`](diffhunk://#diff-551b1eec69db8a0b1f35eb2a6f21141402bc419c4d5aa143741c02cf0963c026R11-R18): Added `JsonConstructor` attribute to the constructor of `DatasetUserAccessLevelsDto`.