### PR TITLE
chore: fix flfuentassertion version to 7 but not 8

### DIFF
--- a/src/OStats.Tests/OStats.Tests.csproj
+++ b/src/OStats.Tests/OStats.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.1.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
This pull request includes a small change to the `src/OStats.Tests/OStats.Tests.csproj` file. The change updates the version range for the `FluentAssertions` package to ensure compatibility with versions between 7.0.0 and 8.0.0.

* [`src/OStats.Tests/OStats.Tests.csproj`](diffhunk://#diff-bb4b737b2f41833fa433e50773ac98353587c9ee85a9150d2f250d7062e96bc2L13-R13): Updated `FluentAssertions` package reference to version range `[7.0.0,8.0.0)`.